### PR TITLE
Reduce preloader delay

### DIFF
--- a/static/datro/js/preloader/main.js
+++ b/static/datro/js/preloader/main.js
@@ -13,10 +13,8 @@ Enjoy responsibly!
 */
 
 $(document).ready(function() {
-	
-	setTimeout(function(){
-		$('body').addClass('loaded');
-		$('h1').css('color','#34485D')
-	}, 3000);
+
+        $('body').addClass('loaded');
+        $('h1').css('color','#34485D');
 
 });


### PR DESCRIPTION
## Summary
- load preloader styles immediately instead of delaying by 3 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684480a274bc8320b9076134f91f87ea