### PR TITLE
Fix typos and remove duplicates in html/css

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,12 @@
 	<meta charset="utf-8">
 	<link href="//datro.xyz/index.html" rel="canonical">
 		<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no" name="viewport"><!-- GitHub Pages -->
-	<script type="type/javascript">
-	                var host = "datro.xyz";
-	                if {{ host == window.location.host} && {window.location.protocol != "https:""}}
-	                window.location.protocol = "https";
-	</script>
+        <script type="text/javascript">
+            var host = "datro.xyz";
+            if (host == window.location.host && window.location.protocol != "https:") {
+                window.location.protocol = "https";
+            }
+        </script>
 	<meta content="DATRO Consortium" name="description">
 	<meta content="Unclehowell" name="author">
 	<title>DATRO Consortium</title>
@@ -32,7 +33,6 @@
 	<!-- <link href="https://getbootstrap.com/docs/4.1/dist/css/bootstrap.min.css" rel="stylesheet"> -->
         <link href="static/datro/css/bootstrap.min.css" rel="stylesheet">
         <link href="static/datro/css/reset.min.css" rel="stylesheet">
-        <link href="static/datro/css/bootstrap.min.css" rel="stylesheet">
 	<link href="static/datro/css/featherlight.css" rel="stylesheet" type="text/css">
 	<link href="static/datro/css/style.css" rel="stylesheet">
 	<link href="static/datro/css/carousel.css" rel="stylesheet">
@@ -432,8 +432,6 @@ Crown Copyright <script>new Date().getFullYear()>2017&&document.write("© "+new 
 	<script src="static/datro/js/currencydrop.js">
 	</script>
 	<script src="static/datro/js/scale.fix.js">
-	</script>
-	<script src="static/datro/js/jquery.min.js">
 	</script>
 	<script src="static/datro/html/featherlight/release/featherlight.min.js">
 	</script>

--- a/static/datro/contactus.html
+++ b/static/datro/contactus.html
@@ -44,7 +44,7 @@
 		<!-- <link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">  Google Search Console Reported AMP Error  -->
 
 		<style>
-		html {overflow-y: scroll!Important; background-color;transparent!important; background:transparent!important;}
+                html {overflow-y: scroll!Important; background-color:transparent!important; background:transparent!important;}
 		body {background-color:transparent!important; background:transparent!important;}
 		.segment  {background-color:transparent!important; background:transparent!important;}
 		</style>

--- a/static/datro/css/input.css
+++ b/static/datro/css/input.css
@@ -5347,8 +5347,8 @@ v:after{
 	margin:0;
 	padding-top:55.5px;
 	padding-bottom:0;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
+        vertical-align:top
 }
 .segment{
 	padding-left:5vw;
@@ -5356,8 +5356,8 @@ v:after{
 	height:inherit;
 	padding-top:2rem;
 	padding-bottom:2rem;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
+        vertical-align:top
 }
 .segment-bottom{
 	display:flex;
@@ -5367,8 +5367,8 @@ v:after{
 	height:inherit;
 	padding-top:calc(10vh);
 	padding-bottom:1rem;
-	background:0 0;
-	verticle-align:top
+        background:0 0;
+        vertical-align:top
 }
 .segment-title{
 	color:#d3d3d3!Important;

--- a/static/datro/css/style.css
+++ b/static/datro/css/style.css
@@ -206,7 +206,7 @@ v:after{
 	padding-top:55.5px;
 	padding-bottom:0;
 	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
-	verticle-align:top
+        vertical-align:top
 }
 .segment{
 	padding-left:5vw;
@@ -214,8 +214,8 @@ v:after{
 	height:inherit;
 	padding-top:2rem;
 	padding-bottom:2rem;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
+        vertical-align:top
 }
 .segment-bottom{
 	display:flex;
@@ -225,8 +225,8 @@ v:after{
 	height:inherit;
 	padding-top:calc(10vh);
 	padding-bottom:1rem;
-	background:0 0;
-	verticle-align:top
+        background:0 0;
+        vertical-align:top
 }
 .segment-title{
 	color:#d3d3d3!Important;

--- a/static/datro/docs-intro.html
+++ b/static/datro/docs-intro.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 		
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		</style>

--- a/static/datro/gpl.html
+++ b/static/datro/gpl.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		.segment-title {background-image: url(../img/heckert_gnu.transp.small.png)!important;}

--- a/static/datro/html/contactus.html
+++ b/static/datro/html/contactus.html
@@ -44,7 +44,7 @@
 		<!-- <link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">  Google Search Console Reported AMP Error  -->
 
 		<style>
-		html {overflow-y: scroll!Important; background-color;transparent!important; background:transparent!important;}
+                html {overflow-y: scroll!Important; background-color:transparent!important; background:transparent!important;}
 		body {background-color:transparent!important; background:transparent!important;}
 		.segment  {background-color:transparent!important; background:transparent!important;}
 		</style>

--- a/static/datro/html/docs-intro.html
+++ b/static/datro/html/docs-intro.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 		
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		</style>

--- a/static/datro/html/gpl.html
+++ b/static/datro/html/gpl.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		.segment-title {background-image: url(../img/heckert_gnu.transp.small.png)!important;}

--- a/static/datro/html/intro.html
+++ b/static/datro/html/intro.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		</style>

--- a/static/datro/html/wavedistributors.html
+++ b/static/datro/html/wavedistributors.html
@@ -53,7 +53,7 @@
 		<link rel="stylesheet" href="search-box/app.css">
 
 		<style amp-custom>
-		html {overflow: hidden; background-color;transparent!important; background:transparent!important;}
+                html {overflow: hidden; background-color:transparent!important; background:transparent!important;}
 		body {background-color:transparent!important; background:transparent!important;}
 		.segment  {background-color:transparent!important; background:transparent!important;}
 		p {    text-shadow: 1px 1px white;}

--- a/static/datro/intro.html
+++ b/static/datro/intro.html
@@ -49,7 +49,7 @@
 		<link rel="stylesheet" href="https://www.jqueryscript.net/css/jquerysctipttop.css" type="text/css">
 
 		<style amp-custom>
-		html {overflow-y: scroll!Important; background-color;#333366!important; background:#333366!important; }
+                html {overflow-y: scroll!Important; background-color:#333366!important; background:#333366!important; }
 		body {background-color:#333366!important; background:#333366!important;}
 		.segment  {background-color:#333366!important; background:#333366!important;}
 		</style>

--- a/static/datro/wavedistributors.html
+++ b/static/datro/wavedistributors.html
@@ -53,7 +53,7 @@
 		<link rel="stylesheet" href="search-box/app.css">
 
 		<style amp-custom>
-		html {overflow: hidden; background-color;transparent!important; background:transparent!important;}
+                html {overflow: hidden; background-color:transparent!important; background:transparent!important;}
 		body {background-color:transparent!important; background:transparent!important;}
 		.segment  {background-color:transparent!important; background:transparent!important;}
 		p {    text-shadow: 1px 1px white;}

--- a/static/gui/dashboard/css/search/style.css
+++ b/static/gui/dashboard/css/search/style.css
@@ -200,8 +200,8 @@ v:after{
 	margin:0;
 	padding-top:55.5px;
 	padding-bottom:0;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
+        vertical-align:top
 }
 .segment{
 	padding-left:5vw;
@@ -209,8 +209,8 @@ v:after{
 	height:inherit;
 	padding-top:2rem;
 	padding-bottom:2rem;
-	background:#454545;
-	verticle-align:top
+        background:#454545;
+        vertical-align:top
 }
 .segment-bottom{
 	display:flex;
@@ -220,8 +220,8 @@ v:after{
 	height:inherit;
 	padding-top:calc(10vh);
 	padding-bottom:1rem;
-	background:0 0;
-	verticle-align:top
+        background:0 0;
+        vertical-align:top
 }
 .segment-title{
 	color:#d3d3d3!Important;

--- a/static/library/consortium_plans/test_network/latest/build/html/css/style.css
+++ b/static/library/consortium_plans/test_network/latest/build/html/css/style.css
@@ -200,8 +200,8 @@ v:after{
 	margin:0;
 	padding-top:55.5px;
 	padding-bottom:0;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#f3f5f8),to(#fff));
+        vertical-align:top
 }
 .segment{
 	padding-left:5vw;
@@ -209,8 +209,8 @@ v:after{
 	height:inherit;
 	padding-top:2rem;
 	padding-bottom:2rem;
-	background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
-	verticle-align:top
+        background:-webkit-gradient(radial,50% 50%,450,50% 50%,860,from(#333434),to(#33335d));
+        vertical-align:top
 }
 .segment-bottom{
 	display:flex;
@@ -220,8 +220,8 @@ v:after{
 	height:inherit;
 	padding-top:calc(10vh);
 	padding-bottom:1rem;
-	background:0 0;
-	verticle-align:top
+        background:0 0;
+        vertical-align:top
 }
 .segment-title{
 	color:#d3d3d3!Important;


### PR DESCRIPTION
## Summary
- fix JavaScript type typo in index.html
- remove duplicate `bootstrap.min.css` and jQuery includes
- correct `verticle-align` typos in multiple style sheets
- fix malformed `background-color` declarations in html files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847086872688320adb8b974d150e475