### PR TITLE
Improve timeline layout spacing and subtitle placement

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -245,7 +245,8 @@
 
     .timeline-century__entries {
       position: relative;
-      padding: 56px 0;
+      padding-top: 56px;
+      padding-bottom: calc(56px + var(--entries-extra-padding, 0px));
       min-height: calc(var(--century-span, 100) * var(--year-scale));
       margin-top: 32px;
       overflow: visible;
@@ -308,14 +309,14 @@
     }
 
     .timeline-century__tick-label {
-      font-size: 0.7rem;
+      font-size: 0.6rem;
       font-weight: 600;
       letter-spacing: 0.08em;
       color: var(--heading-color);
       background: var(--surface);
       border: 1px solid var(--surface-border);
       border-radius: 9999px;
-      padding: 2px 8px;
+      padding: 2px 7px;
       box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.65);
     }
 
@@ -438,13 +439,14 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 0.75rem 1rem;
+      padding: 0.6rem 0.85rem;
       border-radius: 9999px;
       background: var(--surface);
       border: 1px solid var(--surface-border);
       box-shadow: var(--shadow-soft);
       color: var(--heading-color);
       font-weight: 700;
+      font-size: 0.9rem;
       letter-spacing: 0.06em;
       text-transform: uppercase;
     }
@@ -787,7 +789,6 @@
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
         <div class="flex flex-wrap items-center justify-center gap-3">
-          <div class="flex flex-wrap items-center justify-center gap-3">
           <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
           <div class="flex items-center gap-2">
             <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -377,11 +377,11 @@
   }
 
   function resetEntryLayout(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
+    if (!section) {
       return;
     }
     const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
+    if (!entries) {
       return;
     }
     entries.querySelectorAll('.timeline-entry').forEach(entry => {
@@ -390,6 +390,44 @@
       entry.style.removeProperty('--connector-length');
       entry.style.removeProperty('--entry-y-offset');
     });
+    entries.style.removeProperty('--entries-extra-padding');
+    delete entries.dataset.baseHeight;
+  }
+
+  function updateEntriesHeight(entries) {
+    if (!entries) {
+      return;
+    }
+    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
+    if (!entryNodes.length) {
+      entries.style.removeProperty('--entries-extra-padding');
+      delete entries.dataset.baseHeight;
+      return;
+    }
+
+    if (!entries.dataset.baseHeight) {
+      entries.dataset.baseHeight = String(entries.offsetHeight);
+    }
+
+    const baseHeight = Number(entries.dataset.baseHeight) || entries.offsetHeight;
+    const containerRect = entries.getBoundingClientRect();
+    const containerTop = containerRect.top;
+
+    let maxBottom = baseHeight;
+    entryNodes.forEach(entry => {
+      const rect = entry.getBoundingClientRect();
+      const bottom = rect.bottom - containerTop;
+      if (bottom > maxBottom) {
+        maxBottom = bottom;
+      }
+    });
+
+    const extra = Math.max(0, Math.ceil(maxBottom - baseHeight));
+    if (extra > 0) {
+      entries.style.setProperty('--entries-extra-padding', `${extra}px`);
+    } else {
+      entries.style.removeProperty('--entries-extra-padding');
+    }
   }
 
   function updateConnectorLengths(section) {
@@ -448,6 +486,8 @@
           const yearOffset = yearOffsets.has(entry) ? yearOffsets.get(entry) : 0;
           entry.style.setProperty('--entry-y-offset', `${yearOffset}px`);
         });
+
+        updateEntriesHeight(entries);
       });
 
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
- move the case subtitle beneath the Great House Farm title while keeping the theme controls grouped beside the heading
- reduce the size of timeline year badges and tick labels for a tidier axis presentation
- extend each expanded century section dynamically so earlier centuries shift downward instead of overlapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4d46e339083209aaa0838e4af1413