### PR TITLE
Polish timeline header layout and spacing

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -107,6 +107,75 @@
       outline-offset: 3px;
     }
 
+    .controls-group {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: stretch;
+      gap: 12px;
+      width: 100%;
+      max-width: 520px;
+    }
+
+    .controls-group__buttons {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    .century-select {
+      position: relative;
+      display: inline-block;
+      flex: 1 1 220px;
+      min-width: 220px;
+      width: 100%;
+      appearance: none;
+      -webkit-appearance: none;
+      padding: 0.8rem 3.25rem 0.8rem 1.1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(37, 99, 235, 0.35);
+      background: linear-gradient(135deg, rgba(219, 234, 254, 0.96), rgba(191, 219, 254, 0.92));
+      color: #1e293b;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      box-shadow: 0 18px 34px -24px rgba(37, 99, 235, 0.55);
+      transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      cursor: pointer;
+      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%233256eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 1.1rem center;
+      background-size: 18px;
+    }
+
+    .century-select:disabled {
+      cursor: progress;
+      opacity: 0.7;
+    }
+
+    .century-select:focus,
+    .century-select:focus-visible {
+      border-color: rgba(37, 99, 235, 0.75);
+      box-shadow: 0 18px 34px -20px rgba(37, 99, 235, 0.6), 0 0 0 4px rgba(59, 130, 246, 0.25);
+      outline: none;
+      transform: translateY(-1px);
+    }
+
+    body[data-theme='dark'] .century-select {
+      border-color: rgba(96, 165, 250, 0.45);
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.86));
+      color: #e2e8f0;
+      box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.85);
+      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%2396a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    }
+
+    body[data-theme='dark'] .century-select:focus,
+    body[data-theme='dark'] .century-select:focus-visible {
+      border-color: rgba(147, 197, 253, 0.8);
+      box-shadow: 0 18px 34px -22px rgba(8, 47, 73, 0.85), 0 0 0 4px rgba(96, 165, 250, 0.35);
+    }
+
     .intro-panel {
       background: var(--surface);
       border-radius: 18px;
@@ -165,6 +234,10 @@
       max-width: 980px;
       margin: 0 auto;
       padding: 24px 0 64px;
+    }
+
+    .timeline-section {
+      padding-bottom: 20vh;
     }
 
     .timeline-century + .timeline-century {
@@ -786,10 +859,13 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <div class="flex flex-wrap items-center justify-center gap-3">
-          <div class="flex flex-wrap items-center justify-center gap-3">
-          <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-          <div class="flex items-center gap-2">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
             <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
@@ -799,8 +875,10 @@
               <span class="sr-only">Toggle introduction</span>
             </button>
           </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
         </div>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
       </div>
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
@@ -809,7 +887,7 @@
       </div>
     </header>
 
-    <section class="mt-14">
+    <section class="mt-14 timeline-section">
       <div id="timeline-loading" class="text-center loading-text">Loading timeline data…</div>
       <div class="timeline" id="timeline" aria-live="polite"></div>
     </section>

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -8,6 +8,8 @@
   const caseSubtitle = document.getElementById('case-subtitle');
   const caseIntro = document.getElementById('case-intro');
   const keyThemes = document.getElementById('key-themes');
+  const centurySelector = document.getElementById('century-selector');
+  const centurySelect = document.getElementById('century-select');
   const timelineContainer = document.getElementById('timeline');
   const loadingMessage = document.getElementById('timeline-loading');
   const modal = document.getElementById('modal');
@@ -21,6 +23,7 @@
   const storageKey = 'ghf-theme';
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
   let sharedSidePreference = 'right';
+  let centuriesData = [];
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -121,7 +124,7 @@
       return 0;
     }
     const clamped = Math.min(Math.max(year, startYear), endYear);
-    const offset = endYear - clamped;
+    const offset = clamped - startYear;
     const raw = (offset / span) * 100;
     return Math.min(98, Math.max(2, raw));
   }
@@ -138,7 +141,7 @@
     scale.appendChild(ticks);
 
     const { startYear, endYear, span } = bounds;
-    for (let year = endYear; year >= startYear; year -= 1) {
+    for (let year = startYear; year <= endYear; year += 1) {
       const tick = document.createElement('div');
       tick.className = 'timeline-century__tick timeline-century__tick--year';
       if (year % 5 === 0) {
@@ -151,7 +154,7 @@
         tick.classList.add('timeline-century__tick--century');
       }
 
-      const offset = ((endYear - year) / span) * 100;
+      const offset = ((year - startYear) / span) * 100;
       const position = Math.min(100, Math.max(0, offset));
       tick.style.top = `${position}%`;
 
@@ -466,100 +469,145 @@
     });
   }
 
-  function applyCenturyState(section, entries, control, expanded) {
-    section.classList.toggle('timeline-century--collapsed', !expanded);
-    entries.hidden = !expanded;
-    entries.setAttribute('aria-hidden', expanded ? 'false' : 'true');
-    control.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    if (!expanded) {
-      resetEntryLayout(section);
+  function buildCenturySection(century, index) {
+    const section = document.createElement('section');
+    section.className = 'timeline-century';
+
+    const header = document.createElement('div');
+    header.className = 'timeline-century__header';
+
+    const heading = document.createElement('h2');
+    heading.className = 'timeline-century__heading';
+    const headingText = century.title || 'Century of occupation';
+    heading.textContent = century.range ? `${headingText} (${century.range})` : headingText;
+    header.appendChild(heading);
+
+    section.appendChild(header);
+
+    if (century.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'timeline-century__summary';
+      summary.textContent = century.summary;
+      section.appendChild(summary);
     }
+
+    const entries = document.createElement('div');
+    entries.className = 'timeline-century__entries';
+    const idSeed = (century.id || `century-${index + 1}`).toString();
+    const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    entries.id = `${normalizedId || `century-${index + 1}`}-entries`;
+
+    const bounds = normalizeCenturyBounds(century);
+    entries.style.setProperty('--century-span', String(bounds.span || 100));
+    buildCenturyScale(entries, bounds);
+
+    const events = Array.isArray(century.events) ? [...century.events] : [];
+    events.sort((a, b) => {
+      const yearA = getEventYearValue(a, bounds);
+      const yearB = getEventYearValue(b, bounds);
+      if (yearA === yearB) {
+        return (a.label || a.id || '').localeCompare(b.label || b.id || '');
+      }
+      return yearA - yearB;
+    });
+    events.forEach(event => {
+      const entry = buildEvent(event, century, bounds);
+      entries.appendChild(entry);
+    });
+
+    section.appendChild(entries);
+    return section;
   }
 
-  function renderTimeline(data) {
+  function showEmptyTimelineState() {
+    timelineContainer.innerHTML = '';
+    const empty = document.createElement('p');
+    empty.className = 'text-center text-slate-500 dark:text-slate-300';
+    empty.textContent = 'No timeline entries available.';
+    timelineContainer.appendChild(empty);
+  }
+
+  function displayCentury(value) {
+    if (!Array.isArray(centuriesData) || !centuriesData.length) {
+      showEmptyTimelineState();
+      return;
+    }
+
+    let record = centuriesData.find(entry => entry.value === value);
+    if (!record) {
+      [record] = centuriesData;
+      if (!record) {
+        showEmptyTimelineState();
+        return;
+      }
+      if (centurySelect) {
+        centurySelect.value = record.value;
+      }
+    }
+
     timelineContainer.innerHTML = '';
     eventIndex.clear();
     sharedSidePreference = 'right';
 
+    const section = buildCenturySection(record.century, record.index);
+    timelineContainer.appendChild(section);
+    scheduleLayout();
+  }
+
+  function renderTimeline(data) {
     const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
-    centuries.forEach((century, index) => {
-      const section = document.createElement('section');
-      section.className = 'timeline-century';
-
-      const header = document.createElement('div');
-      header.className = 'timeline-century__header';
-
-      const heading = document.createElement('h2');
-      heading.className = 'timeline-century__heading';
-
-      const headingButton = document.createElement('button');
-      headingButton.type = 'button';
-      headingButton.className = 'timeline-century__heading-button';
-      headingButton.textContent = century.title || 'Century of occupation';
-      heading.appendChild(headingButton);
-
-      header.appendChild(heading);
-
-      const entries = document.createElement('div');
-      entries.className = 'timeline-century__entries';
+    centuriesData = centuries.map((century, index) => {
       const idSeed = (century.id || `century-${index + 1}`).toString();
       const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      const entriesId = `${normalizedId || `century-${index + 1}`}-entries`;
-      entries.id = entriesId;
-
-      headingButton.setAttribute('aria-controls', entriesId);
-      headingButton.setAttribute('aria-expanded', 'false');
-      headingButton.addEventListener('click', () => {
-        const currentlyExpanded = !section.classList.contains('timeline-century--collapsed');
-        const nextState = !currentlyExpanded;
-        applyCenturyState(section, entries, headingButton, nextState);
-        scheduleLayout();
-      });
-
-      section.appendChild(header);
-
-      if (century.summary) {
-        const summary = document.createElement('p');
-        summary.className = 'timeline-century__summary';
-        summary.textContent = century.summary;
-        section.appendChild(summary);
-      }
-
-      const bounds = normalizeCenturyBounds(century);
-      entries.style.setProperty('--century-span', String(bounds.span || 100));
-      buildCenturyScale(entries, bounds);
-
-      const events = Array.isArray(century.events) ? [...century.events] : [];
-      events.sort((a, b) => {
-        const yearA = getEventYearValue(a, bounds);
-        const yearB = getEventYearValue(b, bounds);
-        if (yearA === yearB) {
-          return (a.label || a.id || '').localeCompare(b.label || b.id || '');
-        }
-        return yearB - yearA;
-      });
-      events.forEach(event => {
-        const entry = buildEvent(event, century, bounds);
-        entries.appendChild(entry);
-      });
-
-      section.appendChild(entries);
-      timelineContainer.appendChild(section);
-
-      const isTwentiethCentury = /twentieth/i.test(String(century.title || ''))
-        || /1900/.test(String(century.range || ''))
-        || (century.id && /century-4/i.test(String(century.id)));
-      applyCenturyState(section, entries, headingButton, Boolean(isTwentiethCentury));
+      return {
+        century,
+        index,
+        value: normalizedId || `century-${index + 1}`,
+      };
     });
 
-    if (!centuries.length) {
-      const empty = document.createElement('p');
-      empty.className = 'text-center text-slate-500 dark:text-slate-300';
-      empty.textContent = 'No timeline entries available.';
-      timelineContainer.appendChild(empty);
-    } else {
-      scheduleLayout();
+    if (centurySelect) {
+      centurySelect.innerHTML = '';
+      if (!centuriesData.length) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'No centuries available';
+        centurySelect.appendChild(option);
+        centurySelect.disabled = true;
+      } else {
+        centuriesData.forEach(entry => {
+          const option = document.createElement('option');
+          option.value = entry.value;
+          const title = entry.century.title || entry.century.range || `Century ${entry.index + 1}`;
+          if (entry.century.title && entry.century.range) {
+            option.textContent = `${entry.century.title} (${entry.century.range})`;
+          } else {
+            option.textContent = title;
+          }
+          centurySelect.appendChild(option);
+        });
+        centurySelect.disabled = centuriesData.length <= 1;
+      }
+
+      if (centurySelector) {
+        centurySelector.classList.toggle('hidden', !centuriesData.length);
+      }
+
+      centurySelect.onchange = event => {
+        displayCentury(event.target.value);
+      };
     }
+
+    if (!centuriesData.length) {
+      showEmptyTimelineState();
+      return;
+    }
+
+    const defaultCentury = centuriesData[0];
+    if (centurySelect) {
+      centurySelect.value = defaultCentury.value;
+    }
+    displayCentury(defaultCentury.value);
   }
 
   function renderIntro(data) {


### PR DESCRIPTION
## Summary
- reposition the subtitle beneath the title and group the theme/info toggles with the century selector controls
- add modern styling to the century dropdown and ensure the controls row adapts across screen sizes
- provide extra breathing room below the timeline section for improved spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebcda7f42c83209ab9f55b46ae073c