### PR TITLE
Add entry detail pages and polish timeline interactions

### DIFF
--- a/static/bpvsbuckler/entries/1100s-medieval-monastery.html
+++ b/static/bpvsbuckler/entries/1100s-medieval-monastery.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Llandough hosts an early monastery and medieval grange – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1100s-medieval-monastery">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Llandough hosts an early monastery and medieval grange</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">12th century • Medieval and Tudor foundations • 1100–1599</p>
+        <h2 id="entry-heading" class="detail-heading">Llandough hosts an early monastery and medieval grange</h2>
+        <p id="entry-summary" class="detail-summary">Long before the Williams family era, the Llandough holding served as a monastic centre and, later, a grange farm leased by Tewkesbury Abbey.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1600s-family-overview.html
+++ b/static/bpvsbuckler/entries/1600s-family-overview.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Williams stewardship anchors the family&#x27;s later claims – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1600s-family-overview">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams stewardship anchors the family&#x27;s later claims</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1600s • Seventeenth century • 1600–1699</p>
+        <h2 id="entry-heading" class="detail-heading">Williams stewardship anchors the family&#x27;s later claims</h2>
+        <p id="entry-summary" class="detail-summary">Family narratives and estate notes place the Williams ancestors at Great House Farm throughout the Stuart era, laying the foundations for later Buckler claims.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1600s-williams-lease.html
+++ b/static/bpvsbuckler/entries/1600s-williams-lease.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Williams family establishes tenancy at Great House Farm – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1600s-williams-lease">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams family establishes tenancy at Great House Farm</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">c. 1600 • Seventeenth century • 1600–1699</p>
+        <h2 id="entry-heading" class="detail-heading">Williams family establishes tenancy at Great House Farm</h2>
+        <p id="entry-summary" class="detail-summary">Family oral history places the Williams ancestors on Great House Farm at the start of the seventeenth century, beginning a four-hundred-year relationship with the Llandough holding.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1650s-farmstead-notes.html
+++ b/static/bpvsbuckler/entries/1650s-farmstead-notes.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Estate surveys describe the seventeenth-century farmstead – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1650s-farmstead-notes">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Estate surveys describe the seventeenth-century farmstead</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">Mid-1600s • Seventeenth century • 1600–1699</p>
+        <h2 id="entry-heading" class="detail-heading">Estate surveys describe the seventeenth-century farmstead</h2>
+        <p id="entry-summary" class="detail-summary">Estate notes quoted in the family blog describe Great House Farm's orchard, meadow, and dovecote while confirming Williams stewardship through the Commonwealth period.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1700s-family-overview.html
+++ b/static/bpvsbuckler/entries/1700s-family-overview.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eighteenth-century records confirm Williams continuity – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1700s-family-overview">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Eighteenth-century records confirm Williams continuity</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1700s • Eighteenth century • 1700–1799</p>
+        <h2 id="entry-heading" class="detail-heading">Eighteenth-century records confirm Williams continuity</h2>
+        <p id="entry-summary" class="detail-summary">Parish registers and estate correspondence cited in the blog show the Williams family maintaining possession across the eighteenth century.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1700s-parish-registers.html
+++ b/static/bpvsbuckler/entries/1700s-parish-registers.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parish registers maintain the Williams line at Llandough – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1700s-parish-registers">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Parish registers maintain the Williams line at Llandough</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1700s • Eighteenth century • 1700–1799</p>
+        <h2 id="entry-heading" class="detail-heading">Parish registers maintain the Williams line at Llandough</h2>
+        <p id="entry-summary" class="detail-summary">Baptisms, marriages, and burials reproduced in the blog demonstrate that successive Williams generations remained at Great House Farm throughout the eighteenth century.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1790s-bute-renewal.html
+++ b/static/bpvsbuckler/entries/1790s-bute-renewal.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Estate correspondence renews the family&#x27;s tenure – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1790s-bute-renewal">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Estate correspondence renews the family&#x27;s tenure</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">Late 1700s • Eighteenth century • 1700–1799</p>
+        <h2 id="entry-heading" class="detail-heading">Estate correspondence renews the family&#x27;s tenure</h2>
+        <p id="entry-summary" class="detail-summary">According to the blog, late eighteenth-century letters from the Bute estate confirmed the Williams family's continued tenancy and obligations at Great House Farm.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1800s-family-overview.html
+++ b/static/bpvsbuckler/entries/1800s-family-overview.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Victorian sources trace the shift toward the Bucklers – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1800s-family-overview">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Victorian sources trace the shift toward the Bucklers</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1800s • Nineteenth century • 1800–1899</p>
+        <h2 id="entry-heading" class="detail-heading">Victorian sources trace the shift toward the Bucklers</h2>
+        <p id="entry-summary" class="detail-summary">Victorian-era maps and marriages documented in the blog show the Williams holding transitioning toward the Buckler family by the end of the nineteenth century.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1840s-tithe-map.html
+++ b/static/bpvsbuckler/entries/1840s-tithe-map.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tithe surveys list Great House Farm under Williams occupation – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1840s-tithe-map">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Tithe surveys list Great House Farm under Williams occupation</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1840s • Nineteenth century • 1800–1899</p>
+        <h2 id="entry-heading" class="detail-heading">Tithe surveys list Great House Farm under Williams occupation</h2>
+        <p id="entry-summary" class="detail-summary">Tithe apportionments cited in the blog record Great House Farm, its orchard, and meadow being worked by the Williams family in mid-nineteenth-century Llandough.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1880s-soldier-find.html
+++ b/static/bpvsbuckler/entries/1880s-soldier-find.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1880s-soldier-find">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">c. 1880 • Nineteenth century • 1800–1899</p>
+        <h2 id="entry-heading" class="detail-heading">Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse</h2>
+        <p id="entry-summary" class="detail-summary">Late nineteenth-century renovations exposed the skeleton of an armoured horseman beneath the dining room floor, fuelling stories of medieval conflict at Great House Farm.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1890s-buckler-marriage.html
+++ b/static/bpvsbuckler/entries/1890s-buckler-marriage.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Williams heirs marry into the Buckler family – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1890s-buckler-marriage">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams heirs marry into the Buckler family</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1890s • Nineteenth century • 1800–1899</p>
+        <h2 id="entry-heading" class="detail-heading">Williams heirs marry into the Buckler family</h2>
+        <p id="entry-summary" class="detail-summary">The blog notes that late nineteenth-century marriages connected the Williams daughters to Frederick Buckler, setting the stage for Mary Buckler (née Williams) to claim inheritance of the farm.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1897-marconi-visit.html
+++ b/static/bpvsbuckler/entries/1897-marconi-visit.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Marconi conducts wireless experiments with help from Great House Farm – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1897-marconi-visit">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Marconi conducts wireless experiments with help from Great House Farm</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1897 • Nineteenth century • 1800–1899</p>
+        <h2 id="entry-heading" class="detail-heading">Marconi conducts wireless experiments with help from Great House Farm</h2>
+        <p id="entry-summary" class="detail-summary">In May 1897 Guglielmo Marconi stayed at Great House Farm while organising the pioneering wireless telegraphy tests between Lavernock Point and Flat Holm, relying on the Williams family for transport and support.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1900s-family-overview.html
+++ b/static/bpvsbuckler/entries/1900s-family-overview.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Twentieth-century battles end in the Court of Appeal – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1900s-family-overview">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Twentieth-century battles end in the Court of Appeal</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1980s • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Twentieth-century battles end in the Court of Appeal</h2>
+        <p id="entry-summary" class="detail-summary">Twentieth-century tenancies, litigation, and community advocacy culminated in the Court of Appeal decision in <em>BP v Buckler</em> (1987).</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1916-tenancy.html
+++ b/static/bpvsbuckler/entries/1916-tenancy.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Yearly tenancy granted to John Williams – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1916-tenancy">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Yearly tenancy granted to John Williams</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1916 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Yearly tenancy granted to John Williams</h2>
+        <p id="entry-summary" class="detail-summary">The Marquess of Bute lets Great House Farm, including its farmhouse and garden, to John Williams—Mary Buckler's father—on an agricultural yearly tenancy.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1938-reversion.html
+++ b/static/bpvsbuckler/entries/1938-reversion.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reversion conveyed to Western Ground Rents – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1938-reversion">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Reversion conveyed to Western Ground Rents</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1938 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Reversion conveyed to Western Ground Rents</h2>
+        <p id="entry-summary" class="detail-summary">Estate management company Western Ground Rents Ltd. acquires the reversionary interest in Great House Farm. Frederick Buckler succeeds to the protected tenancy after marrying Mary Williams.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1953-arrears.html
+++ b/static/bpvsbuckler/entries/1953-arrears.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Last rent payment under court pressure – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1953-arrears">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Last rent payment under court pressure</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1953 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Last rent payment under court pressure</h2>
+        <p id="entry-summary" class="detail-summary">Frederick Buckler makes the final recorded rent payment for the farmhouse and garden pursuant to a county court judgment for arrears.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1955-notice.html
+++ b/static/bpvsbuckler/entries/1955-notice.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notice to quit and Order 14 possession judgment – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1955-notice">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Notice to quit and Order 14 possession judgment</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1955 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Notice to quit and Order 14 possession judgment</h2>
+        <p id="entry-summary" class="detail-summary">Western Ground Rents serves a statutory notice to quit on the Bucklers and successfully seeks summary judgment for possession and mesne profits under the then Order 14 procedure.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1959-ownership-claim.html
+++ b/static/bpvsbuckler/entries/1959-ownership-claim.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mary Buckler asserts inherited ownership – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1959-ownership-claim">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler asserts inherited ownership</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1959 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Mary Buckler asserts inherited ownership</h2>
+        <p id="entry-summary" class="detail-summary">Mary Buckler concludes that her family already owns Great House Farm by inheritance from her grandfather John Williams and refuses further tenancy overtures.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1960s-land-developed.html
+++ b/static/bpvsbuckler/entries/1960s-land-developed.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Housing estate and school rise on Great House Farm&#x27;s former fields – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1960s-land-developed">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Housing estate and school rise on Great House Farm&#x27;s former fields</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1960s • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Housing estate and school rise on Great House Farm&#x27;s former fields</h2>
+        <p id="entry-summary" class="detail-summary">By the late 1960s Great House Farm's acreage was carved up for suburban housing and, in 1970, a new primary school, shrinking the land surrounding the farmhouse.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1962-high-court.html
+++ b/static/bpvsbuckler/entries/1962-high-court.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Western Ground Rents files High Court action – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1962-high-court">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Western Ground Rents files High Court action</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1962 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Western Ground Rents files High Court action</h2>
+        <p id="entry-summary" class="detail-summary">The company commences fresh proceedings in the High Court seeking possession of the farmhouse and garden together with mesne profits accruing since 1955.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1963-committal.html
+++ b/static/bpvsbuckler/entries/1963-committal.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Suspended committal order against Frederick Buckler – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1963-committal">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Suspended committal order against Frederick Buckler</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1963 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Suspended committal order against Frederick Buckler</h2>
+        <p id="entry-summary" class="detail-summary">A judge issues, then suspends, a committal order against Frederick Buckler for failing to give up possession in obedience to the 1955 order.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1965-tenancy-offer.html
+++ b/static/bpvsbuckler/entries/1965-tenancy-offer.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mary Buckler refuses renewed tenancy – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1965-tenancy-offer">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler refuses renewed tenancy</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1965 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Mary Buckler refuses renewed tenancy</h2>
+        <p id="entry-summary" class="detail-summary">Western Ground Rents seeks to regularise matters by offering Mary Buckler a fresh tenancy; she declines, insisting she already owns the property.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1967-frederick-death.html
+++ b/static/bpvsbuckler/entries/1967-frederick-death.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Frederick Buckler dies; Mary and children remain – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1967-frederick-death">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Frederick Buckler dies; Mary and children remain</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1965–1967 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Frederick Buckler dies; Mary and children remain</h2>
+        <p id="entry-summary" class="detail-summary">Frederick Buckler passes away in the mid-1960s, leaving Mary Buckler and their children—William among them—in sole occupation of the farmhouse.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1969-sale-to-bp.html
+++ b/static/bpvsbuckler/entries/1969-sale-to-bp.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BP Pension Trust purchases the estate – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1969-sale-to-bp">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">BP Pension Trust purchases the estate</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1969 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">BP Pension Trust purchases the estate</h2>
+        <p id="entry-summary" class="detail-summary">Western Ground Rents sells Great House Farm and the surrounding estate to BP Pension Trust Ltd., passing on the benefit of prior possession orders.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1974-cc-proceedings.html
+++ b/static/bpvsbuckler/entries/1974-cc-proceedings.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BP issues county court proceedings but offers licence – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1974-cc-proceedings">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">BP issues county court proceedings but offers licence</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1974 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">BP issues county court proceedings but offers licence</h2>
+        <p id="entry-summary" class="detail-summary">BP Pension Trust issues fresh possession proceedings but, under pressure from a 1,700-signature petition, writes to Mary Buckler offering a rent-free licence that would acknowledge BP's title.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1976-parliament.html
+++ b/static/bpvsbuckler/entries/1976-parliament.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Case raised in the House of Commons – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1976-parliament">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Case raised in the House of Commons</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1976 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Case raised in the House of Commons</h2>
+        <p id="entry-summary" class="detail-summary">MPs reference the Buckler family's position during a Westminster debate on housing hardship in Cardiff, pressing ministers on BP's stewardship of Great House Farm.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1979-roman-villa.html
+++ b/static/bpvsbuckler/entries/1979-roman-villa.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Roman villa remains are discovered on former Great House Farm land – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1979-roman-villa">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Roman villa remains are discovered on former Great House Farm land</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1979 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Roman villa remains are discovered on former Great House Farm land</h2>
+        <p id="entry-summary" class="detail-summary">Construction work on the southern fields in 1979 exposed the remains of a second- to fourth-century Roman villa, complete with mosaic flooring and a hypocaust bath system.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1983-mary-buckler-death.html
+++ b/static/bpvsbuckler/entries/1983-mary-buckler-death.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mary Buckler&#x27;s passing leaves her son to continue the fight – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1983-mary-buckler-death">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler&#x27;s passing leaves her son to continue the fight</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1983 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Mary Buckler&#x27;s passing leaves her son to continue the fight</h2>
+        <p id="entry-summary" class="detail-summary">Mary Buckler (née Williams) dies in 1983 after decades at Great House Farm, leaving her son William to press the family's adverse possession claim alone.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1985-county-court.html
+++ b/static/bpvsbuckler/entries/1985-county-court.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>County court finds licence defeats adverse possession – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1985-county-court">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">County court finds licence defeats adverse possession</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1985 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">County court finds licence defeats adverse possession</h2>
+        <p id="entry-summary" class="detail-summary">A Cardiff County Court judge holds that BP's 1974 letters created a licence, preventing William Buckler from completing the 12-year adverse possession period. Judgment is entered for BP, with execution stayed to allow an appeal.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1987-court-of-appeal.html
+++ b/static/bpvsbuckler/entries/1987-court-of-appeal.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Court of Appeal dismisses William Buckler&#x27;s appeal – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1987-court-of-appeal">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Court of Appeal dismisses William Buckler&#x27;s appeal</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1987 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Court of Appeal dismisses William Buckler&#x27;s appeal</h2>
+        <p id="entry-summary" class="detail-summary">On 17 February 1987 the Court of Appeal (Slade, Croom-Johnson and Nourse LJJ) rules that BP's 1974 letters granted an unrevoked licence, interrupting adverse possession. William Buckler's appeal is dismissed.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1988-demolition.html
+++ b/static/bpvsbuckler/entries/1988-demolition.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Great House Farm is demolished after 33 years of dispute – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1988-demolition">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Great House Farm is demolished after 33 years of dispute</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1988 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Great House Farm is demolished after 33 years of dispute</h2>
+        <p id="entry-summary" class="detail-summary">On the night of 6 December 1988 BP Properties demolished Great House Farm soon after securing legal victory, ending the Williams/Buckler family's four centuries on the site.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1990-archaeology-watch.html
+++ b/static/bpvsbuckler/entries/1990-archaeology-watch.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Archaeologists survey the cleared site ahead of redevelopment – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1990-archaeology-watch">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Archaeologists survey the cleared site ahead of redevelopment</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1990 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Archaeologists survey the cleared site ahead of redevelopment</h2>
+        <p id="entry-summary" class="detail-summary">Trial trenches dug by the Glamorgan-Gwent Archaeological Trust in 1990 mapped the demolished farmhouse and recommended watching briefs for the most sensitive areas before construction proceeded.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1991-commentary.html
+++ b/static/bpvsbuckler/entries/1991-commentary.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Academic commentary consolidates the precedent – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1991-commentary">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Academic commentary consolidates the precedent</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1991 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Academic commentary consolidates the precedent</h2>
+        <p id="entry-summary" class="detail-summary">Property law textbooks and journals adopt <em>BP v Buckler</em> as a leading example of licences stopping adverse possession clock.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/1994-cemetery-excavation.html
+++ b/static/bpvsbuckler/entries/1994-cemetery-excavation.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Excavation uncovers an early-medieval cemetery beneath the farm – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="1994-cemetery-excavation">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Excavation uncovers an early-medieval cemetery beneath the farm</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1994 • Twentieth century • 1900–1999</p>
+        <h2 id="entry-heading" class="detail-heading">Excavation uncovers an early-medieval cemetery beneath the farm</h2>
+        <p id="entry-summary" class="detail-summary">Before new housing went up in 1994, archaeologists excavated 1,026 burials dating from the seventh to tenth centuries, proving that Great House Farm once formed part of a major monastic settlement.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -1,0 +1,373 @@
+:root {
+  color-scheme: light;
+  --page-background: #f3f4f6;
+  --surface: rgba(255, 255, 255, 0.94);
+  --surface-muted: rgba(255, 255, 255, 0.82);
+  --surface-border: rgba(59, 130, 246, 0.16);
+  --heading-color: #0f172a;
+  --text-primary: #1f2937;
+  --text-muted: rgba(17, 24, 39, 0.75);
+  --text-soft: rgba(17, 24, 39, 0.6);
+  --accent-primary: #2563eb;
+  --accent-primary-strong: #1e3a8a;
+  --accent-muted: rgba(59, 130, 246, 0.18);
+  --shadow-soft: 0 22px 36px -24px rgba(15, 23, 42, 0.55);
+  --shadow-strong: 0 30px 52px -32px rgba(15, 23, 42, 0.65);
+}
+
+body[data-theme='dark'] {
+  color-scheme: dark;
+  --page-background: #060b16;
+  --surface: rgba(15, 23, 42, 0.9);
+  --surface-muted: rgba(30, 41, 59, 0.82);
+  --surface-border: rgba(96, 165, 250, 0.28);
+  --heading-color: #e2e8f0;
+  --text-primary: #e2e8f0;
+  --text-muted: rgba(203, 213, 225, 0.85);
+  --text-soft: rgba(148, 163, 184, 0.8);
+  --accent-primary: #60a5fa;
+  --accent-primary-strong: #bfdbfe;
+  --accent-muted: rgba(96, 165, 250, 0.32);
+  --shadow-soft: 0 24px 44px -26px rgba(8, 47, 73, 0.7);
+  --shadow-strong: 0 34px 56px -30px rgba(8, 47, 73, 0.85);
+}
+
+body {
+  background: var(--page-background);
+  color: var(--text-primary);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+a {
+  color: var(--accent-primary);
+}
+
+.page-title {
+  color: var(--heading-color);
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+}
+
+.round-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, var(--accent-primary), rgba(37, 99, 235, 0.85));
+  color: #ffffff;
+  font-size: 1.35rem;
+  border: none;
+  box-shadow: 0 16px 36px -20px rgba(37, 99, 235, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body[data-theme='dark'] .round-button {
+  color: var(--heading-color);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(59, 130, 246, 0.75));
+  box-shadow: 0 18px 40px -22px rgba(30, 64, 175, 0.65);
+}
+
+.round-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px -18px rgba(37, 99, 235, 0.55);
+}
+
+.round-button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 3px;
+}
+
+.controls-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: stretch;
+  gap: 12px;
+  width: 100%;
+  max-width: 520px;
+}
+
+.controls-group__buttons {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.century-select {
+  position: relative;
+  display: inline-block;
+  flex: 1 1 220px;
+  min-width: 220px;
+  width: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 0.8rem 3.25rem 0.8rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: linear-gradient(135deg, rgba(219, 234, 254, 0.96), rgba(191, 219, 254, 0.92));
+  color: #1e293b;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 18px 34px -24px rgba(37, 99, 235, 0.55);
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%233256eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1.1rem center;
+  background-size: 18px;
+}
+
+.century-select option {
+  background-color: rgba(219, 234, 254, 0.96);
+  color: #1e293b;
+}
+
+.century-select:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.century-select:focus,
+.century-select:focus-visible {
+  border-color: rgba(37, 99, 235, 0.75);
+  box-shadow: 0 18px 34px -20px rgba(37, 99, 235, 0.6), 0 0 0 4px rgba(59, 130, 246, 0.25);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+body[data-theme='dark'] .century-select {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.86));
+  color: #e2e8f0;
+  box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.85);
+  background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%2396a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+body[data-theme='dark'] .century-select option {
+  background-color: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+}
+
+body[data-theme='dark'] .century-select:focus,
+body[data-theme='dark'] .century-select:focus-visible {
+  border-color: rgba(147, 197, 253, 0.8);
+  box-shadow: 0 18px 34px -22px rgba(8, 47, 73, 0.85), 0 0 0 4px rgba(96, 165, 250, 0.35);
+}
+
+.intro-panel {
+  background: var(--surface);
+  border-radius: 18px;
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 28px 48px -28px rgba(15, 23, 42, 0.55);
+  padding: 28px 32px;
+  margin: 28px auto 0;
+  max-width: 720px;
+  text-align: left;
+}
+
+.intro-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.intro-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  background: var(--surface-muted);
+  border: 1px solid var(--surface-border);
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.intro-panel__close:hover,
+.intro-panel__close:focus-visible {
+  transform: translateY(-1px);
+  outline: none;
+  box-shadow: 0 20px 32px -24px rgba(37, 99, 235, 0.35);
+}
+
+body[data-theme='dark'] .intro-panel__close {
+  background: rgba(15, 23, 42, 0.92);
+  color: var(--heading-color);
+}
+
+.intro-heading {
+  color: var(--accent-primary-strong);
+}
+
+.intro-body p {
+  color: var(--text-muted);
+}
+
+.intro-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.intro-card {
+  background: var(--surface-muted);
+  border-radius: 16px;
+  border: 1px solid var(--surface-border);
+  padding: 20px 22px;
+  box-shadow: var(--shadow-soft);
+}
+
+.intro-card h3 {
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.intro-card ul {
+  color: var(--text-muted);
+  margin: 0;
+  padding-left: 1.1rem;
+  list-style: disc;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-content {
+  max-width: 780px;
+  margin: 3.5rem auto 0;
+  padding-bottom: 48vh;
+}
+
+.detail-card {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-strong);
+  padding: 2.5rem 2.75rem;
+}
+
+body[data-theme='dark'] .detail-card {
+  background: rgba(15, 23, 42, 0.92);
+}
+
+.detail-meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+  margin-bottom: 1.2rem;
+}
+
+.detail-heading {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--heading-color);
+  margin-bottom: 1.5rem;
+}
+
+.detail-summary {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+.detail-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--surface-border);
+}
+
+.detail-section h3 {
+  font-size: 0.95rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+  margin-bottom: 0.75rem;
+}
+
+.detail-section ul {
+  list-style: disc;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: var(--text-muted);
+}
+
+.detail-evidence-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-evidence-item {
+  background: var(--surface-muted);
+  border-radius: 16px;
+  border: 1px solid var(--surface-border);
+  padding: 1.1rem 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.detail-evidence-item h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--heading-color);
+  margin-bottom: 0.5rem;
+}
+
+.detail-evidence-item p {
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.detail-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 2.5rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-primary-strong);
+}
+
+body[data-theme='dark'] .detail-evidence-item {
+  background: rgba(30, 41, 59, 0.88);
+}
+
+body[data-theme='dark'] .detail-back-link {
+  color: var(--accent-primary-strong);
+}
+
+@media (max-width: 768px) {
+  .round-button {
+    width: 40px;
+    height: 40px;
+    font-size: 1.2rem;
+  }
+
+  .detail-card {
+    padding: 2rem 1.75rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .intro-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .detail-evidence-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/static/bpvsbuckler/entry.js
+++ b/static/bpvsbuckler/entry.js
@@ -1,0 +1,389 @@
+(function () {
+  const body = document.body;
+  const entryId = body.dataset.entryId;
+  const storageKey = 'ghf-theme';
+
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeIcon = themeToggle ? themeToggle.querySelector('[data-theme-icon]') : null;
+  const introToggle = document.getElementById('intro-toggle');
+  const introPanel = document.getElementById('intro-panel');
+  const introClose = document.getElementById('intro-close');
+  const caseTitle = document.getElementById('case-title');
+  const caseSubtitle = document.getElementById('case-subtitle');
+  const caseIntro = document.getElementById('case-intro');
+  const keyThemes = document.getElementById('key-themes');
+  const centurySelector = document.getElementById('century-selector');
+  const centurySelect = document.getElementById('century-select');
+  const entryMeta = document.getElementById('entry-meta');
+  const entryHeading = document.getElementById('entry-heading');
+  const entrySummary = document.getElementById('entry-summary');
+  const entryContext = document.getElementById('entry-context');
+  const entryContextList = document.getElementById('entry-context-list');
+  const entryEvidence = document.getElementById('entry-evidence');
+  const entryEvidenceList = document.getElementById('entry-evidence-list');
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function setTheme(theme, persist = true) {
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+    body.dataset.theme = normalized;
+    if (themeToggle) {
+      themeToggle.setAttribute('aria-pressed', normalized === 'dark' ? 'true' : 'false');
+      themeToggle.setAttribute('title', normalized === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+    }
+    if (themeIcon) {
+      themeIcon.textContent = normalized === 'dark' ? '🌙' : '☀️';
+    }
+    if (persist) {
+      try {
+        localStorage.setItem(storageKey, normalized);
+      } catch (error) {
+        // ignore persistence issues
+      }
+    }
+  }
+
+  const savedTheme = (() => {
+    try {
+      return localStorage.getItem(storageKey);
+    } catch (error) {
+      return null;
+    }
+  })();
+
+  if (savedTheme) {
+    setTheme(savedTheme, false);
+  } else {
+    setTheme(prefersDark.matches ? 'dark' : 'light', false);
+  }
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const next = body.dataset.theme === 'dark' ? 'light' : 'dark';
+      setTheme(next, true);
+    });
+  }
+
+  prefersDark.addEventListener('change', event => {
+    try {
+      if (!localStorage.getItem(storageKey)) {
+        setTheme(event.matches ? 'dark' : 'light', false);
+      }
+    } catch (error) {
+      setTheme(event.matches ? 'dark' : 'light', false);
+    }
+  });
+
+  function updateIntroState(nextState) {
+    if (!introToggle || !introPanel) {
+      return;
+    }
+    introToggle.setAttribute('aria-expanded', String(nextState));
+    introPanel.classList.toggle('hidden', !nextState);
+    introPanel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
+    introToggle.setAttribute('title', nextState ? 'Hide timeline introduction' : 'About this timeline');
+    if (nextState) {
+      introPanel.focus();
+      introPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  if (introToggle && introPanel) {
+    introToggle.addEventListener('click', () => {
+      const isExpanded = introToggle.getAttribute('aria-expanded') === 'true';
+      updateIntroState(!isExpanded);
+    });
+  }
+
+  if (introClose) {
+    introClose.addEventListener('click', () => updateIntroState(false));
+  }
+
+  function renderIntroduction(data) {
+    if (data.caseTitle && caseTitle) {
+      caseTitle.textContent = data.caseTitle;
+    }
+
+    const hasIntro = Array.isArray(data.introduction) && data.introduction.length;
+    if (caseIntro) {
+      caseIntro.innerHTML = '';
+      if (hasIntro) {
+        data.introduction.forEach(paragraph => {
+          const p = document.createElement('p');
+          p.innerHTML = paragraph;
+          caseIntro.appendChild(p);
+        });
+        caseIntro.classList.remove('hidden');
+      } else {
+        caseIntro.classList.add('hidden');
+      }
+    }
+
+    const hasThemes = Array.isArray(data.keyThemes) && data.keyThemes.length;
+    if (keyThemes) {
+      keyThemes.innerHTML = '';
+      if (hasThemes) {
+        data.keyThemes.forEach(theme => {
+          const card = document.createElement('div');
+          card.className = 'intro-card';
+
+          const heading = document.createElement('h3');
+          heading.textContent = theme.title;
+          card.appendChild(heading);
+
+          if (Array.isArray(theme.items) && theme.items.length) {
+            const list = document.createElement('ul');
+            theme.items.forEach(item => {
+              const li = document.createElement('li');
+              li.textContent = item;
+              list.appendChild(li);
+            });
+            card.appendChild(list);
+          }
+
+          keyThemes.appendChild(card);
+        });
+        keyThemes.classList.remove('hidden');
+      } else {
+        keyThemes.classList.add('hidden');
+      }
+    }
+
+    if (introPanel && introToggle) {
+      const hasPanelContent = hasIntro || hasThemes;
+      introPanel.classList.add('hidden');
+      introPanel.setAttribute('aria-hidden', 'true');
+      introToggle.setAttribute('aria-expanded', 'false');
+      introToggle.classList.toggle('hidden', !hasPanelContent);
+      introToggle.setAttribute('title', hasPanelContent ? 'About this timeline' : '');
+      if (introClose) {
+        introClose.classList.toggle('hidden', !hasPanelContent);
+      }
+    }
+  }
+
+  function renderContext(event) {
+    if (!entryContext || !entryContextList) {
+      return;
+    }
+    entryContext.classList.add('hidden');
+    entryContextList.innerHTML = '';
+    if (Array.isArray(event.context) && event.context.length) {
+      event.context.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = item;
+        entryContextList.appendChild(li);
+      });
+      entryContext.classList.remove('hidden');
+    }
+  }
+
+  function renderEvidence(event) {
+    if (!entryEvidence || !entryEvidenceList) {
+      return;
+    }
+    entryEvidence.classList.add('hidden');
+    entryEvidenceList.innerHTML = '';
+
+    if (!Array.isArray(event.evidence) || !event.evidence.length) {
+      return;
+    }
+
+    event.evidence.forEach(evidence => {
+      const block = document.createElement('article');
+      block.className = 'detail-evidence-item';
+
+      const heading = document.createElement('h4');
+      heading.textContent = evidence.title;
+      block.appendChild(heading);
+
+      if (evidence.description) {
+        const description = document.createElement('p');
+        description.textContent = evidence.description;
+        block.appendChild(description);
+      }
+
+      if (Array.isArray(evidence.content) && evidence.content.length) {
+        evidence.content.forEach(paragraph => {
+          const p = document.createElement('p');
+          p.textContent = paragraph;
+          block.appendChild(p);
+        });
+      }
+
+      if (evidence.embed && evidence.embed.type && evidence.embed.src) {
+        if (evidence.embed.type === 'iframe') {
+          const iframe = document.createElement('iframe');
+          iframe.src = evidence.embed.src;
+          iframe.loading = 'lazy';
+          iframe.title = evidence.embed.title || evidence.title;
+          iframe.style.width = '100%';
+          iframe.style.minHeight = '320px';
+          block.appendChild(iframe);
+        } else if (evidence.embed.type === 'object') {
+          const object = document.createElement('object');
+          object.data = evidence.embed.src;
+          object.type = evidence.embed.mime || 'application/pdf';
+          object.style.width = '100%';
+          object.style.minHeight = '320px';
+          block.appendChild(object);
+        }
+      }
+
+      if (evidence.source && (evidence.source.name || evidence.source.url)) {
+        const meta = document.createElement('p');
+        if (evidence.source.url) {
+          const link = document.createElement('a');
+          link.href = evidence.source.url;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          link.textContent = evidence.source.name || evidence.source.url;
+          meta.appendChild(document.createTextNode('Source: '));
+          meta.appendChild(link);
+        } else {
+          meta.textContent = `Source: ${evidence.source.name}`;
+        }
+        block.appendChild(meta);
+      }
+
+      entryEvidenceList.appendChild(block);
+    });
+
+    entryEvidence.classList.remove('hidden');
+  }
+
+  function normaliseCenturyValue(idSeed, fallback) {
+    const normalized = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    return normalized || fallback;
+  }
+
+  function populateCenturies(centuriesData, selectedValue) {
+    if (!centurySelect) {
+      return;
+    }
+    centurySelect.innerHTML = '';
+
+    if (!centuriesData.length) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No centuries available';
+      centurySelect.appendChild(option);
+      centurySelect.disabled = true;
+      if (centurySelector) {
+        centurySelector.classList.add('hidden');
+      }
+      return;
+    }
+
+    centuriesData.forEach(entry => {
+      const option = document.createElement('option');
+      option.value = entry.value;
+      const title = entry.century.title || entry.century.range || `Century ${entry.index + 1}`;
+      option.textContent = entry.century.title && entry.century.range ? `${entry.century.title} (${entry.century.range})` : title;
+      centurySelect.appendChild(option);
+    });
+
+    centurySelect.disabled = centuriesData.length <= 1;
+    if (centurySelector) {
+      centurySelector.classList.toggle('hidden', !centuriesData.length);
+    }
+
+    if (selectedValue) {
+      centurySelect.value = selectedValue;
+    }
+
+    centurySelect.onchange = event => {
+      const value = event.target.value;
+      if (value) {
+        window.location.href = `../index.html?century=${value}`;
+      } else {
+        window.location.href = '../index.html';
+      }
+    };
+  }
+
+  function renderEntry(data) {
+    const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
+    const centuriesData = centuries.map((century, index) => {
+      const idSeed = (century.id || `century-${index + 1}`).toString();
+      return {
+        century,
+        index,
+        value: normaliseCenturyValue(idSeed, `century-${index + 1}`),
+      };
+    });
+
+    let selectedCentury = null;
+    let selectedCenturyValue = null;
+    let selectedEvent = null;
+
+    centuriesData.forEach(entry => {
+      if (selectedEvent) {
+        return;
+      }
+      const events = Array.isArray(entry.century.events) ? entry.century.events : [];
+      events.forEach(event => {
+        if (!selectedEvent && event.id === entryId) {
+          selectedEvent = event;
+          selectedCentury = entry.century;
+          selectedCenturyValue = entry.value;
+        }
+      });
+    });
+
+    if (caseSubtitle && selectedEvent) {
+      caseSubtitle.textContent = selectedEvent.title;
+    }
+
+    if (entryHeading && selectedEvent) {
+      entryHeading.textContent = selectedEvent.title;
+    }
+
+    if (entrySummary && selectedEvent) {
+      entrySummary.innerHTML = selectedEvent.summary;
+    }
+
+    if (entryMeta && selectedEvent) {
+      const parts = [selectedEvent.year];
+      if (selectedCentury) {
+        parts.push(selectedCentury.title || selectedCentury.range);
+        if (selectedCentury.range && selectedCentury.title) {
+          parts.push(selectedCentury.range);
+        }
+      }
+      entryMeta.textContent = parts.filter(Boolean).join(' • ');
+    }
+
+    if (selectedEvent) {
+      renderContext(selectedEvent);
+      renderEvidence(selectedEvent);
+      const pageTitle = data.caseTitle ? `${selectedEvent.title} – ${data.caseTitle} timeline` : selectedEvent.title;
+      document.title = pageTitle;
+    } else if (entrySummary) {
+      entrySummary.textContent = 'We could not find details for this timeline entry.';
+    }
+
+    populateCenturies(centuriesData, selectedCenturyValue);
+  }
+
+  fetch('../data/timeline.json')
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Failed to load timeline data');
+      }
+      return response.json();
+    })
+    .then(data => {
+      renderIntroduction(data);
+      renderEntry(data);
+    })
+    .catch(error => {
+      console.error(error);
+      if (entrySummary) {
+        entrySummary.textContent = 'We were unable to load the entry details. Please try again later.';
+      }
+      if (centurySelector) {
+        centurySelector.classList.add('hidden');
+      }
+    });
+})();

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -107,6 +107,85 @@
       outline-offset: 3px;
     }
 
+    .controls-group {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: stretch;
+      gap: 12px;
+      width: 100%;
+      max-width: 520px;
+    }
+
+    .controls-group__buttons {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    .century-select {
+      position: relative;
+      display: inline-block;
+      flex: 1 1 220px;
+      min-width: 220px;
+      width: 100%;
+      appearance: none;
+      -webkit-appearance: none;
+      padding: 0.8rem 3.25rem 0.8rem 1.1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(37, 99, 235, 0.35);
+      background: linear-gradient(135deg, rgba(219, 234, 254, 0.96), rgba(191, 219, 254, 0.92));
+      color: #1e293b;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      box-shadow: 0 18px 34px -24px rgba(37, 99, 235, 0.55);
+      transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      cursor: pointer;
+      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%233256eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 1.1rem center;
+      background-size: 18px;
+    }
+
+    .century-select option {
+      background-color: rgba(219, 234, 254, 0.96);
+      color: #1e293b;
+    }
+
+    .century-select:disabled {
+      cursor: progress;
+      opacity: 0.7;
+    }
+
+    .century-select:focus,
+    .century-select:focus-visible {
+      border-color: rgba(37, 99, 235, 0.75);
+      box-shadow: 0 18px 34px -20px rgba(37, 99, 235, 0.6), 0 0 0 4px rgba(59, 130, 246, 0.25);
+      outline: none;
+      transform: translateY(-1px);
+    }
+
+    body[data-theme='dark'] .century-select {
+      border-color: rgba(96, 165, 250, 0.45);
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.86));
+      color: #e2e8f0;
+      box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.85);
+      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%2396a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    }
+
+    body[data-theme='dark'] .century-select option {
+      background-color: rgba(15, 23, 42, 0.92);
+      color: #e2e8f0;
+    }
+
+    body[data-theme='dark'] .century-select:focus,
+    body[data-theme='dark'] .century-select:focus-visible {
+      border-color: rgba(147, 197, 253, 0.8);
+      box-shadow: 0 18px 34px -22px rgba(8, 47, 73, 0.85), 0 0 0 4px rgba(96, 165, 250, 0.35);
+    }
+
     .intro-panel {
       background: var(--surface);
       border-radius: 18px;
@@ -116,6 +195,43 @@
       margin: 28px auto 0;
       max-width: 720px;
       text-align: left;
+    }
+
+    .intro-panel__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .intro-panel__close {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 9999px;
+      background: var(--surface-muted);
+      border: 1px solid var(--surface-border);
+      color: var(--text-primary);
+      font-size: 1.2rem;
+      line-height: 1;
+      cursor: pointer;
+      box-shadow: var(--shadow-soft);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .intro-panel__close:hover,
+    .intro-panel__close:focus-visible {
+      transform: translateY(-1px);
+      outline: none;
+      box-shadow: 0 20px 32px -24px rgba(37, 99, 235, 0.35);
+    }
+
+    body[data-theme='dark'] .intro-panel__close {
+      background: rgba(15, 23, 42, 0.92);
+      color: var(--heading-color);
     }
 
     .intro-heading {
@@ -165,6 +281,17 @@
       max-width: 980px;
       margin: 0 auto;
       padding: 24px 0 64px;
+    }
+
+    .timeline::after {
+      content: '';
+      display: block;
+      height: 55vh;
+      max-height: 520px;
+    }
+
+    .timeline-section {
+      padding-bottom: 20vh;
     }
 
     .timeline-century + .timeline-century {
@@ -649,6 +776,41 @@
 
     .modal-description {
       color: var(--text-muted);
+      line-height: 1.6;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .modal-summary-text {
+      display: block;
+    }
+
+    .modal-learn-more {
+      align-self: flex-start;
+      padding: 0.55rem 1.2rem;
+      border-radius: 9999px;
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(37, 99, 235, 0.35));
+      border: 1px solid rgba(37, 99, 235, 0.35);
+      color: var(--accent-primary-strong);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .modal-learn-more:hover,
+    .modal-learn-more:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 20px 34px -24px rgba(37, 99, 235, 0.45);
+      outline: none;
+    }
+
+    body[data-theme='dark'] .modal-learn-more {
+      background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(96, 165, 250, 0.35));
+      border-color: rgba(96, 165, 250, 0.45);
+      color: var(--accent-primary-strong);
     }
 
     .modal-body {
@@ -786,10 +948,13 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <div class="flex flex-wrap items-center justify-center gap-3">
-          <div class="flex flex-wrap items-center justify-center gap-3">
-          <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-          <div class="flex items-center gap-2">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
             <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
@@ -799,17 +964,22 @@
               <span class="sr-only">Toggle introduction</span>
             </button>
           </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
         </div>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
       </div>
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
-        <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
       </div>
     </header>
 
-    <section class="mt-14">
+    <section class="mt-14 timeline-section">
       <div id="timeline-loading" class="text-center loading-text">Loading timeline data…</div>
       <div class="timeline" id="timeline" aria-live="polite"></div>
     </section>

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -4,14 +4,17 @@
   const themeIcon = themeToggle ? themeToggle.querySelector('[data-theme-icon]') : null;
   const introToggle = document.getElementById('intro-toggle');
   const introPanel = document.getElementById('intro-panel');
+  const introClose = document.getElementById('intro-close');
   const caseTitle = document.getElementById('case-title');
   const caseSubtitle = document.getElementById('case-subtitle');
   const caseIntro = document.getElementById('case-intro');
   const keyThemes = document.getElementById('key-themes');
+  const centurySelector = document.getElementById('century-selector');
+  const centurySelect = document.getElementById('century-select');
   const timelineContainer = document.getElementById('timeline');
   const loadingMessage = document.getElementById('timeline-loading');
   const modal = document.getElementById('modal');
-  const closeBtn = modal.querySelector('.close-btn');
+  const closeBtn = modal ? modal.querySelector('.close-btn') : null;
   const modalTitle = document.getElementById('modal-title');
   const modalSource = document.getElementById('modal-source');
   const modalDescription = document.getElementById('modal-description');
@@ -21,6 +24,7 @@
   const storageKey = 'ghf-theme';
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
   let sharedSidePreference = 'right';
+  let centuriesData = [];
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -121,7 +125,7 @@
       return 0;
     }
     const clamped = Math.min(Math.max(year, startYear), endYear);
-    const offset = endYear - clamped;
+    const offset = clamped - startYear;
     const raw = (offset / span) * 100;
     return Math.min(98, Math.max(2, raw));
   }
@@ -138,7 +142,7 @@
     scale.appendChild(ticks);
 
     const { startYear, endYear, span } = bounds;
-    for (let year = endYear; year >= startYear; year -= 1) {
+    for (let year = startYear; year <= endYear; year += 1) {
       const tick = document.createElement('div');
       tick.className = 'timeline-century__tick timeline-century__tick--year';
       if (year % 5 === 0) {
@@ -151,7 +155,7 @@
         tick.classList.add('timeline-century__tick--century');
       }
 
-      const offset = ((endYear - year) / span) * 100;
+      const offset = ((year - startYear) / span) * 100;
       const position = Math.min(100, Math.max(0, offset));
       tick.style.top = `${position}%`;
 
@@ -466,100 +470,171 @@
     });
   }
 
-  function applyCenturyState(section, entries, control, expanded) {
-    section.classList.toggle('timeline-century--collapsed', !expanded);
-    entries.hidden = !expanded;
-    entries.setAttribute('aria-hidden', expanded ? 'false' : 'true');
-    control.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    if (!expanded) {
-      resetEntryLayout(section);
+  function buildCenturySection(century, index) {
+    const section = document.createElement('section');
+    section.className = 'timeline-century';
+
+    const header = document.createElement('div');
+    header.className = 'timeline-century__header';
+
+    const heading = document.createElement('h2');
+    heading.className = 'timeline-century__heading';
+    const headingText = century.title || 'Century of occupation';
+    heading.textContent = century.range ? `${headingText} (${century.range})` : headingText;
+    header.appendChild(heading);
+
+    section.appendChild(header);
+
+    if (century.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'timeline-century__summary';
+      summary.textContent = century.summary;
+      section.appendChild(summary);
     }
+
+    const entries = document.createElement('div');
+    entries.className = 'timeline-century__entries';
+    const idSeed = (century.id || `century-${index + 1}`).toString();
+    const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    entries.id = `${normalizedId || `century-${index + 1}`}-entries`;
+
+    const bounds = normalizeCenturyBounds(century);
+    entries.style.setProperty('--century-span', String(bounds.span || 100));
+    buildCenturyScale(entries, bounds);
+
+    const events = Array.isArray(century.events) ? [...century.events] : [];
+    events.sort((a, b) => {
+      const yearA = getEventYearValue(a, bounds);
+      const yearB = getEventYearValue(b, bounds);
+      if (yearA === yearB) {
+        return (a.label || a.id || '').localeCompare(b.label || b.id || '');
+      }
+      return yearA - yearB;
+    });
+    events.forEach(event => {
+      const entry = buildEvent(event, century, bounds);
+      entries.appendChild(entry);
+    });
+
+    section.appendChild(entries);
+    return section;
   }
 
-  function renderTimeline(data) {
+  function showEmptyTimelineState() {
+    timelineContainer.innerHTML = '';
+    const empty = document.createElement('p');
+    empty.className = 'text-center text-slate-500 dark:text-slate-300';
+    empty.textContent = 'No timeline entries available.';
+    timelineContainer.appendChild(empty);
+  }
+
+  function displayCentury(value) {
+    if (!Array.isArray(centuriesData) || !centuriesData.length) {
+      showEmptyTimelineState();
+      return;
+    }
+
+    let record = centuriesData.find(entry => entry.value === value);
+    if (!record) {
+      [record] = centuriesData;
+      if (!record) {
+        showEmptyTimelineState();
+        return;
+      }
+      if (centurySelect) {
+        centurySelect.value = record.value;
+      }
+    }
+
     timelineContainer.innerHTML = '';
     eventIndex.clear();
     sharedSidePreference = 'right';
 
+    const section = buildCenturySection(record.century, record.index);
+    timelineContainer.appendChild(section);
+    scheduleLayout();
+  }
+
+  function renderTimeline(data) {
     const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
-    centuries.forEach((century, index) => {
-      const section = document.createElement('section');
-      section.className = 'timeline-century';
-
-      const header = document.createElement('div');
-      header.className = 'timeline-century__header';
-
-      const heading = document.createElement('h2');
-      heading.className = 'timeline-century__heading';
-
-      const headingButton = document.createElement('button');
-      headingButton.type = 'button';
-      headingButton.className = 'timeline-century__heading-button';
-      headingButton.textContent = century.title || 'Century of occupation';
-      heading.appendChild(headingButton);
-
-      header.appendChild(heading);
-
-      const entries = document.createElement('div');
-      entries.className = 'timeline-century__entries';
+    centuriesData = centuries.map((century, index) => {
       const idSeed = (century.id || `century-${index + 1}`).toString();
       const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      const entriesId = `${normalizedId || `century-${index + 1}`}-entries`;
-      entries.id = entriesId;
-
-      headingButton.setAttribute('aria-controls', entriesId);
-      headingButton.setAttribute('aria-expanded', 'false');
-      headingButton.addEventListener('click', () => {
-        const currentlyExpanded = !section.classList.contains('timeline-century--collapsed');
-        const nextState = !currentlyExpanded;
-        applyCenturyState(section, entries, headingButton, nextState);
-        scheduleLayout();
-      });
-
-      section.appendChild(header);
-
-      if (century.summary) {
-        const summary = document.createElement('p');
-        summary.className = 'timeline-century__summary';
-        summary.textContent = century.summary;
-        section.appendChild(summary);
-      }
-
-      const bounds = normalizeCenturyBounds(century);
-      entries.style.setProperty('--century-span', String(bounds.span || 100));
-      buildCenturyScale(entries, bounds);
-
-      const events = Array.isArray(century.events) ? [...century.events] : [];
-      events.sort((a, b) => {
-        const yearA = getEventYearValue(a, bounds);
-        const yearB = getEventYearValue(b, bounds);
-        if (yearA === yearB) {
-          return (a.label || a.id || '').localeCompare(b.label || b.id || '');
-        }
-        return yearB - yearA;
-      });
-      events.forEach(event => {
-        const entry = buildEvent(event, century, bounds);
-        entries.appendChild(entry);
-      });
-
-      section.appendChild(entries);
-      timelineContainer.appendChild(section);
-
-      const isTwentiethCentury = /twentieth/i.test(String(century.title || ''))
-        || /1900/.test(String(century.range || ''))
-        || (century.id && /century-4/i.test(String(century.id)));
-      applyCenturyState(section, entries, headingButton, Boolean(isTwentiethCentury));
+      return {
+        century,
+        index,
+        value: normalizedId || `century-${index + 1}`,
+      };
     });
 
-    if (!centuries.length) {
-      const empty = document.createElement('p');
-      empty.className = 'text-center text-slate-500 dark:text-slate-300';
-      empty.textContent = 'No timeline entries available.';
-      timelineContainer.appendChild(empty);
-    } else {
-      scheduleLayout();
+    if (centurySelect) {
+      centurySelect.innerHTML = '';
+      if (!centuriesData.length) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'No centuries available';
+        centurySelect.appendChild(option);
+        centurySelect.disabled = true;
+      } else {
+        centuriesData.forEach(entry => {
+          const option = document.createElement('option');
+          option.value = entry.value;
+          const title = entry.century.title || entry.century.range || `Century ${entry.index + 1}`;
+          if (entry.century.title && entry.century.range) {
+            option.textContent = `${entry.century.title} (${entry.century.range})`;
+          } else {
+            option.textContent = title;
+          }
+          centurySelect.appendChild(option);
+        });
+        centurySelect.disabled = centuriesData.length <= 1;
+      }
+
+      if (centurySelector) {
+        centurySelector.classList.toggle('hidden', !centuriesData.length);
+      }
+
+      centurySelect.onchange = event => {
+        const { value } = event.target;
+        displayCentury(value);
+        try {
+          const url = new URL(window.location.href);
+          if (value) {
+            url.searchParams.set('century', value);
+          } else {
+            url.searchParams.delete('century');
+          }
+          window.history.replaceState(null, '', url);
+        } catch (error) {
+          // ignore URL update issues
+        }
+      };
     }
+
+    if (!centuriesData.length) {
+      showEmptyTimelineState();
+      return;
+    }
+
+    let defaultCentury = centuriesData[0];
+    try {
+      const url = new URL(window.location.href);
+      const searchCentury = url.searchParams.get('century');
+      const hashCentury = window.location.hash ? window.location.hash.replace(/^#/, '') : '';
+      const requested = searchCentury || hashCentury || '';
+      if (requested) {
+        const found = centuriesData.find(entry => entry.value === requested);
+        if (found) {
+          defaultCentury = found;
+        }
+      }
+    } catch (error) {
+      // ignore URL parsing issues
+    }
+    if (centurySelect) {
+      centurySelect.value = defaultCentury.value;
+    }
+    displayCentury(defaultCentury.value);
   }
 
   function renderIntro(data) {
@@ -618,6 +693,9 @@
       introToggle.setAttribute('aria-expanded', 'false');
       introToggle.classList.toggle('hidden', !hasPanelContent);
       introToggle.setAttribute('title', hasPanelContent ? 'About this timeline' : '');
+      if (introClose) {
+        introClose.classList.toggle('hidden', !hasPanelContent);
+      }
     }
   }
 
@@ -717,6 +795,9 @@
   }
 
   function openEvent(eventId) {
+    if (!modal) {
+      return;
+    }
     const record = eventIndex.get(eventId);
     if (!record) {
       return;
@@ -732,10 +813,20 @@
     }
 
     if (event.summary) {
-      modalDescription.textContent = event.summary;
       modalDescription.classList.remove('hidden');
+      modalDescription.innerHTML = '';
+      const summary = document.createElement('span');
+      summary.className = 'modal-summary-text';
+      summary.innerHTML = event.summary;
+      modalDescription.appendChild(summary);
+
+      const learnMoreLink = document.createElement('a');
+      learnMoreLink.className = 'modal-learn-more';
+      learnMoreLink.href = `entries/${encodeURIComponent(event.id)}.html`;
+      learnMoreLink.textContent = 'Learn more';
+      modalDescription.appendChild(learnMoreLink);
     } else {
-      modalDescription.textContent = '';
+      modalDescription.innerHTML = '';
       modalDescription.classList.add('hidden');
     }
 
@@ -757,36 +848,55 @@
   }
 
   function closeModal() {
+    if (!modal) {
+      return;
+    }
     modal.classList.remove('active');
     modal.setAttribute('aria-hidden', 'true');
     document.body.style.overflow = '';
   }
 
-  closeBtn.addEventListener('click', closeModal);
-  modal.addEventListener('click', event => {
-    if (event.target === modal) {
-      closeModal();
-    }
-  });
+  if (closeBtn) {
+    closeBtn.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', event => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
   document.addEventListener('keydown', event => {
-    if (event.key === 'Escape' && modal.classList.contains('active')) {
+    if (event.key === 'Escape' && modal && modal.classList.contains('active')) {
       closeModal();
     }
   });
 
+  function updateIntroState(nextState) {
+    if (!introToggle || !introPanel) {
+      return;
+    }
+    introToggle.setAttribute('aria-expanded', String(nextState));
+    introPanel.classList.toggle('hidden', !nextState);
+    introPanel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
+    introToggle.setAttribute('title', nextState ? 'Hide timeline introduction' : 'About this timeline');
+    if (nextState) {
+      introPanel.focus();
+      introPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
   if (introToggle && introPanel) {
     introToggle.addEventListener('click', () => {
       const isExpanded = introToggle.getAttribute('aria-expanded') === 'true';
-      const nextState = !isExpanded;
-      introToggle.setAttribute('aria-expanded', String(nextState));
-      introPanel.classList.toggle('hidden', !nextState);
-      introPanel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
-      introToggle.setAttribute('title', nextState ? 'Hide timeline introduction' : 'About this timeline');
-      if (nextState) {
-        introPanel.focus();
-        introPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
+      updateIntroState(!isExpanded);
     });
+  }
+
+  if (introClose) {
+    introClose.addEventListener('click', () => updateIntroState(false));
   }
 
   const handleWindowResize = () => scheduleLayout();


### PR DESCRIPTION
## Summary
- refine the century selector styling across themes, add extra timeline breathing room, and provide an accessible close control for the info panel
- update the timeline modal to append a themed “Learn more” link and preserve century selection via URL parameters
- generate dedicated entry detail pages with shared header styling, new entry-specific CSS, and a supporting script that loads timeline data for each record

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebcda7f42c83209ab9f55b46ae073c