### PR TITLE
Add photo album placeholders for each timeline year

### DIFF
--- a/static/bpvsbuckler/entries/photos-1150.html
+++ b/static/bpvsbuckler/entries/photos-1150.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1150 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1150">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1150 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1150</p>
+        <h2 id="entry-heading" class="detail-heading">1150 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1150 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1600.html
+++ b/static/bpvsbuckler/entries/photos-1600.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1600 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1600">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1600 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1600</p>
+        <h2 id="entry-heading" class="detail-heading">1600 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1600 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1650.html
+++ b/static/bpvsbuckler/entries/photos-1650.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1650 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1650">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1650 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1650</p>
+        <h2 id="entry-heading" class="detail-heading">1650 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1650 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1655.html
+++ b/static/bpvsbuckler/entries/photos-1655.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1655 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1655">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1655 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1655</p>
+        <h2 id="entry-heading" class="detail-heading">1655 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1655 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1725.html
+++ b/static/bpvsbuckler/entries/photos-1725.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1725 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1725">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1725 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1725</p>
+        <h2 id="entry-heading" class="detail-heading">1725 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1725 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1750.html
+++ b/static/bpvsbuckler/entries/photos-1750.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1750 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1750">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1750 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1750</p>
+        <h2 id="entry-heading" class="detail-heading">1750 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1750 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1792.html
+++ b/static/bpvsbuckler/entries/photos-1792.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1792 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1792">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1792 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1792</p>
+        <h2 id="entry-heading" class="detail-heading">1792 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1792 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1845.html
+++ b/static/bpvsbuckler/entries/photos-1845.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1845 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1845">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1845 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1845</p>
+        <h2 id="entry-heading" class="detail-heading">1845 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1845 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1880.html
+++ b/static/bpvsbuckler/entries/photos-1880.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1880 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1880">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1880 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1880</p>
+        <h2 id="entry-heading" class="detail-heading">1880 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1880 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1885.html
+++ b/static/bpvsbuckler/entries/photos-1885.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1885 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1885">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1885 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1885</p>
+        <h2 id="entry-heading" class="detail-heading">1885 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1885 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1892.html
+++ b/static/bpvsbuckler/entries/photos-1892.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1892 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1892">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1892 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1892</p>
+        <h2 id="entry-heading" class="detail-heading">1892 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1892 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1897.html
+++ b/static/bpvsbuckler/entries/photos-1897.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1897 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1897">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1897 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1897</p>
+        <h2 id="entry-heading" class="detail-heading">1897 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1897 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1916.html
+++ b/static/bpvsbuckler/entries/photos-1916.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1916 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1916">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1916 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1916</p>
+        <h2 id="entry-heading" class="detail-heading">1916 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1916 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1938.html
+++ b/static/bpvsbuckler/entries/photos-1938.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1938 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1938">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1938 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1938</p>
+        <h2 id="entry-heading" class="detail-heading">1938 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1938 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1953.html
+++ b/static/bpvsbuckler/entries/photos-1953.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1953 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1953">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1953 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1953</p>
+        <h2 id="entry-heading" class="detail-heading">1953 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1953 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1955.html
+++ b/static/bpvsbuckler/entries/photos-1955.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1955 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1955">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1955 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1955</p>
+        <h2 id="entry-heading" class="detail-heading">1955 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1955 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1959.html
+++ b/static/bpvsbuckler/entries/photos-1959.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1959 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1959">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1959 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1959</p>
+        <h2 id="entry-heading" class="detail-heading">1959 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1959 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1962.html
+++ b/static/bpvsbuckler/entries/photos-1962.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1962 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1962">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1962 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1962</p>
+        <h2 id="entry-heading" class="detail-heading">1962 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1962 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1963.html
+++ b/static/bpvsbuckler/entries/photos-1963.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1963 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1963">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1963 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1963</p>
+        <h2 id="entry-heading" class="detail-heading">1963 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1963 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1965.html
+++ b/static/bpvsbuckler/entries/photos-1965.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1965 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1965">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1965 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1965</p>
+        <h2 id="entry-heading" class="detail-heading">1965 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1965 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1966.html
+++ b/static/bpvsbuckler/entries/photos-1966.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1966 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1966">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1966 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1966</p>
+        <h2 id="entry-heading" class="detail-heading">1966 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1966 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1969.html
+++ b/static/bpvsbuckler/entries/photos-1969.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1969 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1969">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1969 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1969</p>
+        <h2 id="entry-heading" class="detail-heading">1969 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1969 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1974.html
+++ b/static/bpvsbuckler/entries/photos-1974.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1974 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1974">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1974 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1974</p>
+        <h2 id="entry-heading" class="detail-heading">1974 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1974 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1976.html
+++ b/static/bpvsbuckler/entries/photos-1976.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1976 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1976">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1976 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1976</p>
+        <h2 id="entry-heading" class="detail-heading">1976 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1976 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1979.html
+++ b/static/bpvsbuckler/entries/photos-1979.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1979 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1979">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1979 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1979</p>
+        <h2 id="entry-heading" class="detail-heading">1979 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1979 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1983.html
+++ b/static/bpvsbuckler/entries/photos-1983.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1983 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1983">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1983 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1983</p>
+        <h2 id="entry-heading" class="detail-heading">1983 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1983 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1985.html
+++ b/static/bpvsbuckler/entries/photos-1985.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1985 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1985">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1985 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1985</p>
+        <h2 id="entry-heading" class="detail-heading">1985 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1985 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1987.html
+++ b/static/bpvsbuckler/entries/photos-1987.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1987 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1987">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1987 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1987</p>
+        <h2 id="entry-heading" class="detail-heading">1987 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1987 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1988.html
+++ b/static/bpvsbuckler/entries/photos-1988.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1988 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1988">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1988 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1988</p>
+        <h2 id="entry-heading" class="detail-heading">1988 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1988 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1990.html
+++ b/static/bpvsbuckler/entries/photos-1990.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1990 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1990">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1990 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1990</p>
+        <h2 id="entry-heading" class="detail-heading">1990 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1990 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1991.html
+++ b/static/bpvsbuckler/entries/photos-1991.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1991 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1991">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1991 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1991</p>
+        <h2 id="entry-heading" class="detail-heading">1991 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1991 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1994.html
+++ b/static/bpvsbuckler/entries/photos-1994.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1994 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1994">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1994 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1994</p>
+        <h2 id="entry-heading" class="detail-heading">1994 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1994 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -306,6 +306,47 @@ body[data-theme='dark'] .detail-card {
   color: var(--text-muted);
 }
 
+.detail-photo-album {
+  margin-top: 2.5rem;
+}
+
+.detail-photo-album .photo-album-placeholder {
+  margin-top: 1.25rem;
+}
+
+.photo-album-placeholder {
+  padding: 1.75rem;
+  border-radius: 18px;
+  border: 2px dashed var(--accent-muted);
+  background: var(--surface-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  text-align: center;
+  color: var(--text-muted);
+  min-height: 200px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.photo-album-placeholder__icon {
+  font-size: 2.85rem;
+}
+
+.photo-album-placeholder__text {
+  font-size: 1.05rem;
+  max-width: 34ch;
+  line-height: 1.65;
+}
+
+body[data-theme='dark'] .photo-album-placeholder {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: var(--text-soft);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+}
+
 .detail-evidence-grid {
   display: grid;
   gap: 1rem;

--- a/static/bpvsbuckler/entry.js
+++ b/static/bpvsbuckler/entry.js
@@ -21,8 +21,80 @@
   const entryContextList = document.getElementById('entry-context-list');
   const entryEvidence = document.getElementById('entry-evidence');
   const entryEvidenceList = document.getElementById('entry-evidence-list');
+  const detailCard = document.querySelector('.detail-card');
+  const detailBackLink = detailCard ? detailCard.querySelector('.detail-back-link') : null;
 
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function createPhotoAlbumEvent(year) {
+    const numericYear = Number(year);
+    if (!Number.isFinite(numericYear)) {
+      return null;
+    }
+    const roundedYear = Math.round(numericYear);
+    const id = `photos-${roundedYear}`;
+    return {
+      id,
+      year: String(roundedYear).padStart(4, '0'),
+      yearValue: roundedYear,
+      side: 'both',
+      title: `${roundedYear} Photos`,
+      summary: `Open the ${roundedYear} photo album to view and organise images from this year.`,
+      icon: '📸',
+      iconLabel: 'Photo album',
+      type: 'photo-album',
+      albumYear: roundedYear,
+    };
+  }
+
+  function extractEventYear(event) {
+    if (!event) {
+      return null;
+    }
+    if (Number.isFinite(event.yearValue)) {
+      return Math.round(event.yearValue);
+    }
+    if (typeof event.year === 'string') {
+      const match = event.year.match(/(1[5-9]\d{2}|20\d{2})/);
+      if (match) {
+        return Number(match[0]);
+      }
+    }
+    if (typeof event.label === 'string') {
+      const match = event.label.match(/(1[5-9]\d{2}|20\d{2})/);
+      if (match) {
+        return Number(match[0]);
+      }
+    }
+    return null;
+  }
+
+  function ensurePhotoAlbumsForCentury(century) {
+    if (!century || !Array.isArray(century.events)) {
+      return;
+    }
+    const existingIds = new Set(century.events.map(event => event.id));
+    const years = new Set();
+
+    century.events.forEach(event => {
+      const year = extractEventYear(event);
+      if (Number.isFinite(year)) {
+        years.add(year);
+      }
+    });
+
+    years.forEach(year => {
+      const id = `photos-${year}`;
+      if (existingIds.has(id)) {
+        return;
+      }
+      const albumEvent = createPhotoAlbumEvent(year);
+      if (albumEvent) {
+        century.events.push(albumEvent);
+        existingIds.add(id);
+      }
+    });
+  }
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -252,6 +324,62 @@
     entryEvidence.classList.remove('hidden');
   }
 
+  function renderPhotoAlbum(event) {
+    if (!detailCard) {
+      return;
+    }
+
+    const existingSection = detailCard.querySelector('.detail-photo-album');
+    if (!event || event.type !== 'photo-album') {
+      if (existingSection) {
+        existingSection.remove();
+      }
+      return;
+    }
+
+    let section = existingSection;
+    if (!section) {
+      section = document.createElement('section');
+      section.className = 'detail-section detail-photo-album';
+
+      const heading = document.createElement('h3');
+      heading.textContent = 'Photo album';
+      section.appendChild(heading);
+
+      const placeholder = document.createElement('div');
+      placeholder.className = 'photo-album-placeholder';
+
+      const icon = document.createElement('div');
+      icon.className = 'photo-album-placeholder__icon';
+      icon.textContent = event.icon || '📸';
+      placeholder.appendChild(icon);
+
+      const text = document.createElement('p');
+      text.className = 'photo-album-placeholder__text';
+      placeholder.appendChild(text);
+
+      section.appendChild(placeholder);
+
+      if (detailBackLink) {
+        detailCard.insertBefore(section, detailBackLink);
+      } else {
+        detailCard.appendChild(section);
+      }
+    }
+
+    const textNode = section.querySelector('.photo-album-placeholder__text');
+    if (textNode) {
+      const albumYear = event.albumYear || event.yearValue || event.year || '';
+      const readableYear = albumYear ? String(albumYear) : 'selected year';
+      textNode.textContent = `This space will showcase the ${readableYear} photo collection.`;
+    }
+
+    const iconNode = section.querySelector('.photo-album-placeholder__icon');
+    if (iconNode) {
+      iconNode.textContent = event.icon || '📸';
+    }
+  }
+
   function normaliseCenturyValue(idSeed, fallback) {
     const normalized = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
     return normalized || fallback;
@@ -304,6 +432,7 @@
 
   function renderEntry(data) {
     const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
+    centuries.forEach(ensurePhotoAlbumsForCentury);
     const centuriesData = centuries.map((century, index) => {
       const idSeed = (century.id || `century-${index + 1}`).toString();
       return {
@@ -357,10 +486,12 @@
     if (selectedEvent) {
       renderContext(selectedEvent);
       renderEvidence(selectedEvent);
+      renderPhotoAlbum(selectedEvent);
       const pageTitle = data.caseTitle ? `${selectedEvent.title} – ${data.caseTitle} timeline` : selectedEvent.title;
       document.title = pageTitle;
     } else if (entrySummary) {
       entrySummary.textContent = 'We could not find details for this timeline entry.';
+      renderPhotoAlbum(null);
     }
 
     populateCenturies(centuriesData, selectedCenturyValue);

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -820,6 +820,43 @@
       color: var(--text-muted);
     }
 
+    .modal-photo-album {
+      margin-top: 4px;
+    }
+
+    .photo-album-placeholder {
+      padding: 28px;
+      border-radius: 18px;
+      border: 2px dashed var(--accent-muted);
+      background: var(--surface-muted);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      text-align: center;
+      color: var(--text-muted);
+      min-height: 180px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    }
+
+    .photo-album-placeholder__icon {
+      font-size: 2.75rem;
+    }
+
+    .photo-album-placeholder__text {
+      font-size: 0.95rem;
+      max-width: 32ch;
+      line-height: 1.6;
+    }
+
+    body[data-theme='dark'] .photo-album-placeholder {
+      background: rgba(15, 23, 42, 0.68);
+      border-color: rgba(96, 165, 250, 0.35);
+      color: var(--text-soft);
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+    }
+
     .modal-section-heading {
       font-size: 0.85rem;
       text-transform: uppercase;

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -26,6 +26,59 @@
   let sharedSidePreference = 'right';
   let centuriesData = [];
 
+  function createPhotoAlbumEvent(year) {
+    const numericYear = Number(year);
+    if (!Number.isFinite(numericYear)) {
+      return null;
+    }
+    const roundedYear = Math.round(numericYear);
+    const id = `photos-${roundedYear}`;
+    return {
+      id,
+      year: String(roundedYear).padStart(4, '0'),
+      yearValue: roundedYear,
+      side: 'both',
+      title: `${roundedYear} Photos`,
+      summary: `Open the ${roundedYear} photo album to view and organise images from this year.`,
+      icon: '📸',
+      iconLabel: 'Photo album',
+      type: 'photo-album',
+      albumYear: roundedYear,
+    };
+  }
+
+  function ensurePhotoAlbumsForCentury(century, bounds) {
+    const baseEvents = Array.isArray(century?.events) ? [...century.events] : [];
+    const existingIds = new Set(baseEvents.map(event => event.id));
+    const years = new Set();
+
+    baseEvents.forEach(event => {
+      const eventYear = getEventYearValue(event, bounds);
+      if (Number.isFinite(eventYear)) {
+        years.add(Math.round(eventYear));
+      } else if (typeof event.year === 'string') {
+        const match = event.year.match(/(1[5-9]\d{2}|20\d{2})/);
+        if (match) {
+          years.add(Number(match[0]));
+        }
+      }
+    });
+
+    years.forEach(year => {
+      const id = `photos-${year}`;
+      if (existingIds.has(id)) {
+        return;
+      }
+      const albumEvent = createPhotoAlbumEvent(year);
+      if (albumEvent) {
+        baseEvents.push(albumEvent);
+        existingIds.add(id);
+      }
+    });
+
+    return baseEvents;
+  }
+
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
     body.dataset.theme = normalized;
@@ -502,7 +555,7 @@
     entries.style.setProperty('--century-span', String(bounds.span || 100));
     buildCenturyScale(entries, bounds);
 
-    const events = Array.isArray(century.events) ? [...century.events] : [];
+    const events = ensurePhotoAlbumsForCentury(century, bounds);
     events.sort((a, b) => {
       const yearA = getEventYearValue(a, bounds);
       const yearB = getEventYearValue(b, bounds);
@@ -840,6 +893,29 @@
     const evidenceSection = buildEvidenceSection(event);
     if (evidenceSection) {
       modalBody.appendChild(evidenceSection);
+    }
+
+    if (event.type === 'photo-album') {
+      const albumWrapper = document.createElement('div');
+      albumWrapper.className = 'modal-photo-album';
+
+      const placeholder = document.createElement('div');
+      placeholder.className = 'photo-album-placeholder';
+
+      const icon = document.createElement('div');
+      icon.className = 'photo-album-placeholder__icon';
+      icon.textContent = event.icon || '📸';
+      placeholder.appendChild(icon);
+
+      const text = document.createElement('p');
+      text.className = 'photo-album-placeholder__text';
+      const albumYear = event.albumYear || event.yearValue || event.year || '';
+      const readableYear = albumYear ? String(albumYear) : 'selected year';
+      text.textContent = `This space will showcase the ${readableYear} photo collection.`;
+      placeholder.appendChild(text);
+
+      albumWrapper.appendChild(placeholder);
+      modalBody.appendChild(albumWrapper);
     }
 
     modal.classList.add('active');


### PR DESCRIPTION
## Summary
- inject photo album events for each timeline year with dedicated modal placeholders and navigation
- extend entry pages to surface photo album placeholders and link through to dedicated yearly photo pages
- add blank photo album entry pages for each year ready to host gallery content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec039b522c832085b441a5ed13e394