### PR TITLE
Prevent timeline overflow and tighten bubble layout

### DIFF
--- a/static/bpvsbuckler/entries/photos-1150.html
+++ b/static/bpvsbuckler/entries/photos-1150.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1150 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1150">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1150 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1150</p>
+        <h2 id="entry-heading" class="detail-heading">1150 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1150 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1600.html
+++ b/static/bpvsbuckler/entries/photos-1600.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1600 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1600">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1600 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1600</p>
+        <h2 id="entry-heading" class="detail-heading">1600 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1600 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1650.html
+++ b/static/bpvsbuckler/entries/photos-1650.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1650 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1650">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1650 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1650</p>
+        <h2 id="entry-heading" class="detail-heading">1650 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1650 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1655.html
+++ b/static/bpvsbuckler/entries/photos-1655.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1655 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1655">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1655 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1655</p>
+        <h2 id="entry-heading" class="detail-heading">1655 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1655 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1725.html
+++ b/static/bpvsbuckler/entries/photos-1725.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1725 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1725">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1725 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1725</p>
+        <h2 id="entry-heading" class="detail-heading">1725 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1725 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1750.html
+++ b/static/bpvsbuckler/entries/photos-1750.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1750 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1750">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1750 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1750</p>
+        <h2 id="entry-heading" class="detail-heading">1750 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1750 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1792.html
+++ b/static/bpvsbuckler/entries/photos-1792.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1792 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1792">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1792 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1792</p>
+        <h2 id="entry-heading" class="detail-heading">1792 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1792 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1845.html
+++ b/static/bpvsbuckler/entries/photos-1845.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1845 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1845">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1845 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1845</p>
+        <h2 id="entry-heading" class="detail-heading">1845 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1845 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1880.html
+++ b/static/bpvsbuckler/entries/photos-1880.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1880 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1880">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1880 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1880</p>
+        <h2 id="entry-heading" class="detail-heading">1880 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1880 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1885.html
+++ b/static/bpvsbuckler/entries/photos-1885.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1885 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1885">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1885 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1885</p>
+        <h2 id="entry-heading" class="detail-heading">1885 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1885 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1892.html
+++ b/static/bpvsbuckler/entries/photos-1892.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1892 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1892">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1892 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1892</p>
+        <h2 id="entry-heading" class="detail-heading">1892 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1892 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1897.html
+++ b/static/bpvsbuckler/entries/photos-1897.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1897 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1897">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1897 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1897</p>
+        <h2 id="entry-heading" class="detail-heading">1897 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1897 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1916.html
+++ b/static/bpvsbuckler/entries/photos-1916.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1916 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1916">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1916 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1916</p>
+        <h2 id="entry-heading" class="detail-heading">1916 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1916 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1938.html
+++ b/static/bpvsbuckler/entries/photos-1938.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1938 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1938">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1938 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1938</p>
+        <h2 id="entry-heading" class="detail-heading">1938 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1938 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1953.html
+++ b/static/bpvsbuckler/entries/photos-1953.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1953 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1953">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1953 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1953</p>
+        <h2 id="entry-heading" class="detail-heading">1953 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1953 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1955.html
+++ b/static/bpvsbuckler/entries/photos-1955.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1955 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1955">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1955 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1955</p>
+        <h2 id="entry-heading" class="detail-heading">1955 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1955 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1959.html
+++ b/static/bpvsbuckler/entries/photos-1959.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1959 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1959">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1959 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1959</p>
+        <h2 id="entry-heading" class="detail-heading">1959 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1959 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1962.html
+++ b/static/bpvsbuckler/entries/photos-1962.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1962 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1962">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1962 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1962</p>
+        <h2 id="entry-heading" class="detail-heading">1962 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1962 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1963.html
+++ b/static/bpvsbuckler/entries/photos-1963.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1963 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1963">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1963 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1963</p>
+        <h2 id="entry-heading" class="detail-heading">1963 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1963 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1965.html
+++ b/static/bpvsbuckler/entries/photos-1965.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1965 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1965">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1965 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1965</p>
+        <h2 id="entry-heading" class="detail-heading">1965 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1965 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1966.html
+++ b/static/bpvsbuckler/entries/photos-1966.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1966 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1966">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1966 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1966</p>
+        <h2 id="entry-heading" class="detail-heading">1966 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1966 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1969.html
+++ b/static/bpvsbuckler/entries/photos-1969.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1969 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1969">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1969 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1969</p>
+        <h2 id="entry-heading" class="detail-heading">1969 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1969 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1974.html
+++ b/static/bpvsbuckler/entries/photos-1974.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1974 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1974">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1974 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1974</p>
+        <h2 id="entry-heading" class="detail-heading">1974 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1974 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1976.html
+++ b/static/bpvsbuckler/entries/photos-1976.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1976 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1976">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1976 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1976</p>
+        <h2 id="entry-heading" class="detail-heading">1976 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1976 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1979.html
+++ b/static/bpvsbuckler/entries/photos-1979.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1979 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1979">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1979 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1979</p>
+        <h2 id="entry-heading" class="detail-heading">1979 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1979 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1983.html
+++ b/static/bpvsbuckler/entries/photos-1983.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1983 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1983">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1983 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1983</p>
+        <h2 id="entry-heading" class="detail-heading">1983 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1983 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1985.html
+++ b/static/bpvsbuckler/entries/photos-1985.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1985 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1985">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1985 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1985</p>
+        <h2 id="entry-heading" class="detail-heading">1985 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1985 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1987.html
+++ b/static/bpvsbuckler/entries/photos-1987.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1987 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1987">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1987 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1987</p>
+        <h2 id="entry-heading" class="detail-heading">1987 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1987 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1988.html
+++ b/static/bpvsbuckler/entries/photos-1988.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1988 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1988">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1988 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1988</p>
+        <h2 id="entry-heading" class="detail-heading">1988 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1988 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1990.html
+++ b/static/bpvsbuckler/entries/photos-1990.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1990 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1990">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1990 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1990</p>
+        <h2 id="entry-heading" class="detail-heading">1990 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1990 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1991.html
+++ b/static/bpvsbuckler/entries/photos-1991.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1991 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1991">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1991 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1991</p>
+        <h2 id="entry-heading" class="detail-heading">1991 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1991 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entries/photos-1994.html
+++ b/static/bpvsbuckler/entries/photos-1994.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1994 Photos – Great House Farm</title>
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="../entry.css">
+</head>
+<body class="font-sans" data-theme="light" data-entry-id="photos-1994">
+  <div class="container mx-auto px-4 py-10">
+    <header class="text-center">
+      <div class="flex flex-col items-center gap-4">
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">1994 Photos</p>
+      </div>
+      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
+        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+        <div class="controls-group">
+          <div class="controls-group__buttons">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+              <span class="sr-only">Toggle colour theme</span>
+              <span aria-hidden="true" data-theme-icon>☀️</span>
+            </button>
+            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
+              <span aria-hidden="true">ℹ️</span>
+              <span class="sr-only">Toggle introduction</span>
+            </button>
+          </div>
+          <select id="century-select" class="century-select" disabled>
+            <option value="">Loading centuries…</option>
+          </select>
+        </div>
+      </div>
+      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
+        <div class="intro-panel__header">
+          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
+          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+        </div>
+        <div id="case-intro" class="intro-body space-y-4"></div>
+        <div id="key-themes" class="intro-grid"></div>
+      </div>
+    </header>
+
+    <main class="detail-content">
+      <article class="detail-card">
+        <p id="entry-meta" class="detail-meta">1994</p>
+        <h2 id="entry-heading" class="detail-heading">1994 Photos</h2>
+        <p id="entry-summary" class="detail-summary">Open the 1994 photo album to view and organise images from this year.</p>
+        <section id="entry-context" class="detail-section hidden">
+          <h3>Context</h3>
+          <ul id="entry-context-list"></ul>
+        </section>
+        <section id="entry-evidence" class="detail-section hidden">
+          <h3>Evidence &amp; records</h3>
+          <div id="entry-evidence-list" class="detail-evidence-grid"></div>
+        </section>
+        <a href="../index.html" class="detail-back-link">&larr; Back to timeline</a>
+      </article>
+    </main>
+  </div>
+
+  <script src="../entry.js"></script>
+</body>
+</html>

--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -306,6 +306,47 @@ body[data-theme='dark'] .detail-card {
   color: var(--text-muted);
 }
 
+.detail-photo-album {
+  margin-top: 2.5rem;
+}
+
+.detail-photo-album .photo-album-placeholder {
+  margin-top: 1.25rem;
+}
+
+.photo-album-placeholder {
+  padding: 1.75rem;
+  border-radius: 18px;
+  border: 2px dashed var(--accent-muted);
+  background: var(--surface-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  text-align: center;
+  color: var(--text-muted);
+  min-height: 200px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.photo-album-placeholder__icon {
+  font-size: 2.85rem;
+}
+
+.photo-album-placeholder__text {
+  font-size: 1.05rem;
+  max-width: 34ch;
+  line-height: 1.65;
+}
+
+body[data-theme='dark'] .photo-album-placeholder {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: var(--text-soft);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+}
+
 .detail-evidence-grid {
   display: grid;
   gap: 1rem;

--- a/static/bpvsbuckler/entry.js
+++ b/static/bpvsbuckler/entry.js
@@ -21,8 +21,80 @@
   const entryContextList = document.getElementById('entry-context-list');
   const entryEvidence = document.getElementById('entry-evidence');
   const entryEvidenceList = document.getElementById('entry-evidence-list');
+  const detailCard = document.querySelector('.detail-card');
+  const detailBackLink = detailCard ? detailCard.querySelector('.detail-back-link') : null;
 
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function createPhotoAlbumEvent(year) {
+    const numericYear = Number(year);
+    if (!Number.isFinite(numericYear)) {
+      return null;
+    }
+    const roundedYear = Math.round(numericYear);
+    const id = `photos-${roundedYear}`;
+    return {
+      id,
+      year: String(roundedYear).padStart(4, '0'),
+      yearValue: roundedYear,
+      side: 'both',
+      title: `${roundedYear} Photos`,
+      summary: `Open the ${roundedYear} photo album to view and organise images from this year.`,
+      icon: '📸',
+      iconLabel: 'Photo album',
+      type: 'photo-album',
+      albumYear: roundedYear,
+    };
+  }
+
+  function extractEventYear(event) {
+    if (!event) {
+      return null;
+    }
+    if (Number.isFinite(event.yearValue)) {
+      return Math.round(event.yearValue);
+    }
+    if (typeof event.year === 'string') {
+      const match = event.year.match(/(1[5-9]\d{2}|20\d{2})/);
+      if (match) {
+        return Number(match[0]);
+      }
+    }
+    if (typeof event.label === 'string') {
+      const match = event.label.match(/(1[5-9]\d{2}|20\d{2})/);
+      if (match) {
+        return Number(match[0]);
+      }
+    }
+    return null;
+  }
+
+  function ensurePhotoAlbumsForCentury(century) {
+    if (!century || !Array.isArray(century.events)) {
+      return;
+    }
+    const existingIds = new Set(century.events.map(event => event.id));
+    const years = new Set();
+
+    century.events.forEach(event => {
+      const year = extractEventYear(event);
+      if (Number.isFinite(year)) {
+        years.add(year);
+      }
+    });
+
+    years.forEach(year => {
+      const id = `photos-${year}`;
+      if (existingIds.has(id)) {
+        return;
+      }
+      const albumEvent = createPhotoAlbumEvent(year);
+      if (albumEvent) {
+        century.events.push(albumEvent);
+        existingIds.add(id);
+      }
+    });
+  }
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -252,6 +324,62 @@
     entryEvidence.classList.remove('hidden');
   }
 
+  function renderPhotoAlbum(event) {
+    if (!detailCard) {
+      return;
+    }
+
+    const existingSection = detailCard.querySelector('.detail-photo-album');
+    if (!event || event.type !== 'photo-album') {
+      if (existingSection) {
+        existingSection.remove();
+      }
+      return;
+    }
+
+    let section = existingSection;
+    if (!section) {
+      section = document.createElement('section');
+      section.className = 'detail-section detail-photo-album';
+
+      const heading = document.createElement('h3');
+      heading.textContent = 'Photo album';
+      section.appendChild(heading);
+
+      const placeholder = document.createElement('div');
+      placeholder.className = 'photo-album-placeholder';
+
+      const icon = document.createElement('div');
+      icon.className = 'photo-album-placeholder__icon';
+      icon.textContent = event.icon || '📸';
+      placeholder.appendChild(icon);
+
+      const text = document.createElement('p');
+      text.className = 'photo-album-placeholder__text';
+      placeholder.appendChild(text);
+
+      section.appendChild(placeholder);
+
+      if (detailBackLink) {
+        detailCard.insertBefore(section, detailBackLink);
+      } else {
+        detailCard.appendChild(section);
+      }
+    }
+
+    const textNode = section.querySelector('.photo-album-placeholder__text');
+    if (textNode) {
+      const albumYear = event.albumYear || event.yearValue || event.year || '';
+      const readableYear = albumYear ? String(albumYear) : 'selected year';
+      textNode.textContent = `This space will showcase the ${readableYear} photo collection.`;
+    }
+
+    const iconNode = section.querySelector('.photo-album-placeholder__icon');
+    if (iconNode) {
+      iconNode.textContent = event.icon || '📸';
+    }
+  }
+
   function normaliseCenturyValue(idSeed, fallback) {
     const normalized = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
     return normalized || fallback;
@@ -304,6 +432,7 @@
 
   function renderEntry(data) {
     const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
+    centuries.forEach(ensurePhotoAlbumsForCentury);
     const centuriesData = centuries.map((century, index) => {
       const idSeed = (century.id || `century-${index + 1}`).toString();
       return {
@@ -357,10 +486,12 @@
     if (selectedEvent) {
       renderContext(selectedEvent);
       renderEvidence(selectedEvent);
+      renderPhotoAlbum(selectedEvent);
       const pageTitle = data.caseTitle ? `${selectedEvent.title} – ${data.caseTitle} timeline` : selectedEvent.title;
       document.title = pageTitle;
     } else if (entrySummary) {
       entrySummary.textContent = 'We could not find details for this timeline entry.';
+      renderPhotoAlbum(null);
     }
 
     populateCenturies(centuriesData, selectedCenturyValue);

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -62,6 +62,7 @@
       background: var(--page-background);
       color: var(--text-primary);
       transition: background 0.3s ease, color 0.3s ease;
+      overflow-x: hidden;
     }
 
     a {
@@ -278,9 +279,11 @@
 
     .timeline {
       position: relative;
+      width: 100%;
       max-width: 980px;
       margin: 0 auto;
       padding: 24px 0 64px;
+      overflow-x: clip;
     }
 
     .timeline::after {
@@ -372,7 +375,7 @@
 
     .timeline-century__entries {
       position: relative;
-      padding: 56px 0;
+      padding: 56px clamp(48px, 8vw, 92px);
       min-height: calc(var(--century-span, 100) * var(--year-scale));
       margin-top: 32px;
       overflow: visible;
@@ -389,6 +392,36 @@
       width: var(--axis-column-width);
       transform: translateX(-50%);
       pointer-events: none;
+      z-index: 2;
+    }
+
+    .timeline-webgl {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      pointer-events: none;
+    }
+
+    .timeline-connectors {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
+      overflow: visible;
+    }
+
+    .timeline-connector-line {
+      fill: none;
+      stroke: rgba(59, 130, 246, 0.45);
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    body[data-theme='dark'] .timeline-connector-line {
+      stroke: rgba(147, 197, 253, 0.55);
     }
 
     .timeline-century__scale::before {
@@ -528,11 +561,11 @@
       grid-template-columns: minmax(0, 1fr) var(--axis-column-width) minmax(0, 1fr);
       column-gap: var(--entry-gap);
       align-items: center;
-      transform: translateY(calc(-50% + var(--entry-y-offset, 0px)));
-      z-index: 2;
-      --bubble-offset: 0px;
+      transform: translateY(-50%);
+      z-index: 3;
+      --bubble-offset: 64px;
       --bubble-scale: 1;
-      --connector-length: calc(var(--entry-gap) + var(--axis-column-width) / 2);
+      --bubble-y-offset: 0px;
     }
 
     .timeline-entry__column {
@@ -565,15 +598,12 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 0.75rem 1rem;
+      width: 32px;
+      height: 32px;
       border-radius: 9999px;
       background: var(--surface);
       border: 1px solid var(--surface-border);
       box-shadow: var(--shadow-soft);
-      color: var(--heading-color);
-      font-weight: 700;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
     }
 
     body[data-theme='dark'] .timeline-node {
@@ -617,7 +647,7 @@
       position: relative;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
       cursor: pointer;
-      transform: translateX(calc(var(--bubble-shift, 0px))) scale(var(--bubble-scale, 1));
+      transform: translate(var(--bubble-translate-x, 0px), var(--bubble-y-offset, 0px)) scale(var(--bubble-scale, 1));
       transform-origin: center;
     }
 
@@ -646,48 +676,21 @@
       transform: translate(-50%, 0);
     }
 
-    .timeline-bubble:hover,
-    .timeline-bubble:focus-visible {
-      transform: translateX(calc(var(--bubble-shift, 0px))) translateY(-3px) scale(var(--bubble-scale, 1));
-      box-shadow: 0 16px 32px -20px rgba(59, 130, 246, 0.45);
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after,
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      height: 2px;
-      transform: translateY(-50%);
-      pointer-events: none;
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after {
-      right: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.75) 0%,
-        rgba(59, 130, 246, 0.68) 74%,
-        rgba(59, 130, 246, 0.92) 100%
-      );
-    }
-
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      left: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.92) 0%,
-        rgba(59, 130, 246, 0.68) 26%,
-        rgba(59, 130, 246, 0.75) 100%
-      );
-    }
+      .timeline-bubble:hover,
+      .timeline-bubble:focus-visible {
+        transform: translate(
+          var(--bubble-translate-x, 0px),
+          calc(var(--bubble-y-offset, 0px) - 3px)
+        ) scale(var(--bubble-scale, 1));
+        box-shadow: 0 16px 32px -20px rgba(59, 130, 246, 0.45);
+      }
 
     .timeline-entry[data-position='left'] .timeline-bubble {
-      --bubble-shift: calc(-1 * var(--bubble-offset, 0px));
+      --bubble-translate-x: calc(-1 * var(--bubble-offset, 0px));
     }
 
     .timeline-entry[data-position='right'] .timeline-bubble {
-      --bubble-shift: var(--bubble-offset, 0px);
+      --bubble-translate-x: var(--bubble-offset, 0px);
     }
 
     .timeline-bubble:focus-visible {
@@ -820,6 +823,43 @@
       color: var(--text-muted);
     }
 
+    .modal-photo-album {
+      margin-top: 4px;
+    }
+
+    .photo-album-placeholder {
+      padding: 28px;
+      border-radius: 18px;
+      border: 2px dashed var(--accent-muted);
+      background: var(--surface-muted);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      text-align: center;
+      color: var(--text-muted);
+      min-height: 180px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    }
+
+    .photo-album-placeholder__icon {
+      font-size: 2.75rem;
+    }
+
+    .photo-album-placeholder__text {
+      font-size: 0.95rem;
+      max-width: 32ch;
+      line-height: 1.6;
+    }
+
+    body[data-theme='dark'] .photo-album-placeholder {
+      background: rgba(15, 23, 42, 0.68);
+      border-color: rgba(96, 165, 250, 0.35);
+      color: var(--text-soft);
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+    }
+
     .modal-section-heading {
       font-size: 0.85rem;
       text-transform: uppercase;
@@ -905,6 +945,7 @@
       .timeline-entry {
         grid-template-columns: var(--axis-column-width) 1fr;
         column-gap: 16px;
+        --bubble-offset: 0px;
       }
 
       .timeline-entry__column--left,
@@ -913,12 +954,20 @@
         justify-content: flex-start;
       }
 
-      .timeline-entry[data-position='left'] .timeline-bubble::after,
-      .timeline-entry[data-position='right'] .timeline-bubble::after {
-        left: calc(-1 * (var(--axis-column-width) - 16px));
-        right: auto;
-        width: calc(var(--axis-column-width) - 12px);
-        background: linear-gradient(90deg, rgba(59, 130, 246, 0.65), rgba(59, 130, 246, 0));
+      .timeline-year {
+        display: flex;
+        justify-content: center;
+      }
+
+      .timeline-node {
+        width: 28px;
+        height: 28px;
+      }
+
+      .timeline-bubble {
+        min-width: var(--bubble-size);
+        height: auto;
+        padding: 0.65rem;
       }
 
       .timeline-entry__column--left.timeline-entry__column--empty,
@@ -928,6 +977,10 @@
     }
 
     @media (max-width: 540px) {
+      :root {
+        --bubble-size: 48px;
+      }
+
       .round-button {
         width: 40px;
         height: 40px;
@@ -936,6 +989,11 @@
 
       .timeline-bubble::before {
         font-size: 0.8rem;
+      }
+
+      .timeline-node {
+        width: 24px;
+        height: 24px;
       }
 
       .modal-content {

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -26,6 +26,59 @@
   let sharedSidePreference = 'right';
   let centuriesData = [];
 
+  function createPhotoAlbumEvent(year) {
+    const numericYear = Number(year);
+    if (!Number.isFinite(numericYear)) {
+      return null;
+    }
+    const roundedYear = Math.round(numericYear);
+    const id = `photos-${roundedYear}`;
+    return {
+      id,
+      year: String(roundedYear).padStart(4, '0'),
+      yearValue: roundedYear,
+      side: 'both',
+      title: `${roundedYear} Photos`,
+      summary: `Open the ${roundedYear} photo album to view and organise images from this year.`,
+      icon: '📸',
+      iconLabel: 'Photo album',
+      type: 'photo-album',
+      albumYear: roundedYear,
+    };
+  }
+
+  function ensurePhotoAlbumsForCentury(century, bounds) {
+    const baseEvents = Array.isArray(century?.events) ? [...century.events] : [];
+    const existingIds = new Set(baseEvents.map(event => event.id));
+    const years = new Set();
+
+    baseEvents.forEach(event => {
+      const eventYear = getEventYearValue(event, bounds);
+      if (Number.isFinite(eventYear)) {
+        years.add(Math.round(eventYear));
+      } else if (typeof event.year === 'string') {
+        const match = event.year.match(/(1[5-9]\d{2}|20\d{2})/);
+        if (match) {
+          years.add(Number(match[0]));
+        }
+      }
+    });
+
+    years.forEach(year => {
+      const id = `photos-${year}`;
+      if (existingIds.has(id)) {
+        return;
+      }
+      const albumEvent = createPhotoAlbumEvent(year);
+      if (albumEvent) {
+        baseEvents.push(albumEvent);
+        existingIds.add(id);
+      }
+    });
+
+    return baseEvents;
+  }
+
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
     body.dataset.theme = normalized;
@@ -76,12 +129,19 @@
     }
   });
 
-  function choosePosition(event) {
-    if (event.side === 'buckler') {
+  function choosePosition(event, counters) {
+    const normalizedSide = typeof event.side === 'string' ? event.side.toLowerCase() : '';
+    if (normalizedSide === 'buckler' || normalizedSide === 'left') {
       return 'left';
     }
-    if (event.side === 'bp') {
+    if (normalizedSide === 'bp' || normalizedSide === 'right') {
       return 'right';
+    }
+    if (counters) {
+      const preferred = counters.left <= counters.right ? 'left' : 'right';
+      if (normalizedSide === 'both' || !normalizedSide) {
+        return preferred;
+      }
     }
     sharedSidePreference = sharedSidePreference === 'left' ? 'right' : 'left';
     return sharedSidePreference;
@@ -176,8 +236,11 @@
     container.prepend(scale);
   }
 
-  function buildEvent(event, century, bounds) {
-    const position = choosePosition(event);
+  function buildEvent(event, century, bounds, counters) {
+    const position = choosePosition(event, counters);
+    if (counters && position in counters) {
+      counters[position] += 1;
+    }
     const entry = document.createElement('div');
     entry.className = 'timeline-entry';
     entry.dataset.position = position;
@@ -202,8 +265,8 @@
     yearWrapper.className = 'timeline-year';
     const node = document.createElement('div');
     node.className = 'timeline-node';
-    const yearLabel = (event.year && String(event.year).trim()) || (Number.isFinite(eventYear) ? String(eventYear) : '');
-    node.textContent = yearLabel || '•';
+    node.textContent = '';
+    node.setAttribute('aria-hidden', 'true');
     yearWrapper.appendChild(node);
     axisColumn.appendChild(yearWrapper);
 
@@ -229,7 +292,7 @@
     })();
 
     const bubbleIcon = typeof event.icon === 'string' && event.icon.trim().length ? event.icon.trim() : null;
-    const bubbleLabel = bubbleIcon || (bubbleYear != null ? String(bubbleYear).padStart(4, '0') : (event.year ? String(event.year) : (event.label || '•')));
+    const bubbleLabel = bubbleIcon || '•';
     const bubbleIconLabel = typeof event.iconLabel === 'string' && event.iconLabel.trim().length ? event.iconLabel.trim() : null;
 
     const accessibilityLabelParts = [event.title];
@@ -272,24 +335,29 @@
   }
 
   const layoutConfig = {
-    step: 28,
-    maxOffset: 180,
-    minScale: 0.65,
-    scaleStep: 0.08,
-    spacing: 14,
-    yearSpacing: 12,
+    baseOffset: 72,
+    compactBaseOffset: 0,
+    stepX: 16,
+    maxOffset: 72,
+    minScale: 0.82,
+    scaleStep: 0.04,
+    verticalSpacing: 28,
+    verticalStep: 20,
+    maxVerticalOffset: 320,
   };
 
   let layoutFrame = null;
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const webglInstances = new WeakMap();
 
-  function computeAdjustedRect(rect, position, offset, scale) {
+  function computeAdjustedRect(rect, position, offsetX, scale, offsetY) {
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
-    const shift = position === 'left' ? -offset : offset;
+    const horizontalShift = position === 'left' ? -offsetX : offsetX;
     const width = rect.width * scale;
     const height = rect.height * scale;
-    const left = centerX + shift - width / 2;
-    const top = centerY - height / 2;
+    const left = centerX + horizontalShift - width / 2;
+    const top = centerY + offsetY - height / 2;
     return {
       left,
       right: left + width,
@@ -298,16 +366,235 @@
     };
   }
 
+  function ensureConnectorsElement(entries) {
+    let connectors = entries.querySelector('.timeline-connectors');
+    if (!connectors) {
+      connectors = document.createElementNS(SVG_NS, 'svg');
+      connectors.classList.add('timeline-connectors');
+      connectors.setAttribute('aria-hidden', 'true');
+      connectors.setAttribute('focusable', 'false');
+      entries.appendChild(connectors);
+    }
+    return connectors;
+  }
+
+  function createShader(gl, type, source) {
+    const shader = gl.createShader(type);
+    if (!shader) {
+      return null;
+    }
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      gl.deleteShader(shader);
+      return null;
+    }
+    return shader;
+  }
+
+  function createProgram(gl, vertexShader, fragmentShader) {
+    const program = gl.createProgram();
+    if (!program) {
+      return null;
+    }
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    const linked = gl.getProgramParameter(program, gl.LINK_STATUS);
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    if (!linked) {
+      gl.deleteProgram(program);
+      return null;
+    }
+    return program;
+  }
+
+  function ensureWebGLBackground(entries) {
+    if (!entries) {
+      return null;
+    }
+    if (webglInstances.has(entries)) {
+      return webglInstances.get(entries);
+    }
+    const canvas = document.createElement('canvas');
+    canvas.className = 'timeline-webgl';
+    entries.prepend(canvas);
+
+    const gl = canvas.getContext('webgl', { antialias: true, alpha: true, premultipliedAlpha: false });
+    if (!gl) {
+      canvas.remove();
+      webglInstances.set(entries, null);
+      return null;
+    }
+
+    const vertexSource = `
+      attribute vec2 a_position;
+      void main() {
+        gl_Position = vec4(a_position, 0.0, 1.0);
+      }
+    `;
+    const fragmentSource = `
+      precision mediump float;
+      uniform vec2 u_resolution;
+      uniform float u_axis;
+      void main() {
+        vec2 st = gl_FragCoord.xy / u_resolution;
+        float distanceFromAxis = abs(st.x - u_axis);
+        float glow = exp(-14.0 * distanceFromAxis * distanceFromAxis);
+        vec3 base = vec3(0.074, 0.108, 0.188);
+        vec3 accent = vec3(0.337, 0.537, 0.933);
+        vec3 color = mix(base, accent, glow);
+        float alpha = 0.08 + 0.32 * glow;
+        gl_FragColor = vec4(color, alpha);
+      }
+    `;
+
+    const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexSource);
+    const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+    if (!vertexShader || !fragmentShader) {
+      canvas.remove();
+      webglInstances.set(entries, null);
+      return null;
+    }
+
+    const program = createProgram(gl, vertexShader, fragmentShader);
+    if (!program) {
+      canvas.remove();
+      webglInstances.set(entries, null);
+      return null;
+    }
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+      -1, -1,
+      1, -1,
+      -1, 1,
+      -1, 1,
+      1, -1,
+      1, 1,
+    ]), gl.STATIC_DRAW);
+
+    const positionLocation = gl.getAttribLocation(program, 'a_position');
+    const resolutionLocation = gl.getUniformLocation(program, 'u_resolution');
+    const axisLocation = gl.getUniformLocation(program, 'u_axis');
+
+    const instance = {
+      gl,
+      canvas,
+      program,
+      buffers: {
+        position: positionBuffer,
+      },
+      locations: {
+        position: positionLocation,
+        resolution: resolutionLocation,
+        axis: axisLocation,
+      },
+    };
+
+    webglInstances.set(entries, instance);
+    return instance;
+  }
+
+  function renderWebGLBackground(entries, axisRatio, width, height) {
+    const instance = ensureWebGLBackground(entries);
+    if (!instance) {
+      return;
+    }
+    const { gl, canvas, program, buffers, locations } = instance;
+    const dpr = window.devicePixelRatio || 1;
+    const pixelWidth = Math.max(1, Math.round(width * dpr));
+    const pixelHeight = Math.max(1, Math.round(height * dpr));
+
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    }
+
+    gl.viewport(0, 0, pixelWidth, pixelHeight);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.useProgram(program);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffers.position);
+    gl.enableVertexAttribArray(locations.position);
+    gl.vertexAttribPointer(locations.position, 2, gl.FLOAT, false, 0, 0);
+    gl.uniform2f(locations.resolution, pixelWidth, pixelHeight);
+    gl.uniform1f(locations.axis, Math.min(1, Math.max(0, axisRatio || 0.5)));
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  }
+
   function rectanglesOverlap(a, b, spacing) {
-    const verticalOverlap = a.bottom > b.top - spacing && a.top < b.bottom + spacing;
-    const horizontalOverlap = a.right > b.left - spacing && a.left < b.right + spacing;
-    return verticalOverlap && horizontalOverlap;
+    const buffer = Math.max(1, Number.isFinite(spacing) ? spacing : 0);
+    return a.bottom > b.top - buffer && a.top < b.bottom + buffer;
+  }
+
+  function updateConnectors(section) {
+    if (!section || section.classList.contains('timeline-century--collapsed')) {
+      return;
+    }
+    const entries = section.querySelector('.timeline-century__entries');
+    if (!entries || entries.hidden) {
+      return;
+    }
+    const connectors = ensureConnectorsElement(entries);
+    const scaleElement = entries.querySelector('.timeline-century__scale');
+    const entriesRect = entries.getBoundingClientRect();
+    const width = Math.max(entriesRect.width, 1);
+    const height = Math.max(entriesRect.height, 1);
+    connectors.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    connectors.setAttribute('width', width);
+    connectors.setAttribute('height', height);
+    connectors.innerHTML = '';
+
+    if (!scaleElement) {
+      renderWebGLBackground(entries, 0.5, width, height);
+      return;
+    }
+
+    const scaleRect = scaleElement.getBoundingClientRect();
+    const axisX = scaleRect.left + scaleRect.width / 2 - entriesRect.left;
+    const axisRatio = width ? axisX / width : 0.5;
+
+    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
+    entryNodes.forEach(entry => {
+      const bubble = entry.querySelector('.timeline-bubble');
+      if (!bubble) {
+        return;
+      }
+      const bubbleRect = bubble.getBoundingClientRect();
+      const bubbleX = bubbleRect.left + bubbleRect.width / 2 - entriesRect.left;
+      const bubbleY = bubbleRect.top + bubbleRect.height / 2 - entriesRect.top;
+      const yearPosition = Number(entry.dataset.yearPosition);
+      if (!Number.isFinite(yearPosition)) {
+        return;
+      }
+      const anchorY = scaleRect.top + (scaleRect.height * (yearPosition / 100)) - entriesRect.top;
+      const path = document.createElementNS(SVG_NS, 'path');
+      const deltaX = bubbleX - axisX;
+      const controlOffset = deltaX * 0.55;
+      const controlY1 = anchorY + (bubbleY - anchorY) * 0.2;
+      const controlY2 = anchorY + (bubbleY - anchorY) * 0.8;
+      const d = `M ${axisX} ${anchorY} C ${axisX + controlOffset} ${controlY1} ${bubbleX - controlOffset} ${controlY2} ${bubbleX} ${bubbleY}`;
+      path.setAttribute('d', d);
+      path.setAttribute('class', 'timeline-connector-line');
+      connectors.appendChild(path);
+    });
+
+    renderWebGLBackground(entries, axisRatio, width, height);
   }
 
   function resolveOverlaps(entries) {
     if (!entries.length) {
       return [];
     }
+    const compactLayout = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(max-width: 760px)').matches
+      : false;
     const data = entries
       .map(entry => {
         const bubble = entry.querySelector('.timeline-bubble');
@@ -321,63 +608,41 @@
       .filter(Boolean)
       .sort((a, b) => a.rect.top - b.rect.top);
 
-    const placements = { left: [], right: [] };
+    const placements = compactLayout ? { shared: [] } : { left: [], right: [] };
     const adjustments = [];
 
     data.forEach(item => {
-      const placed = placements[item.position];
-      let offset = 0;
+      const stackKey = compactLayout ? 'shared' : item.position;
+      const placed = placements[stackKey];
+      const baseOffset = compactLayout ? layoutConfig.compactBaseOffset : layoutConfig.baseOffset;
+      let offset = baseOffset;
       let scale = 1;
-      let candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
+      let vertical = 0;
+      let candidate = computeAdjustedRect(item.rect, item.position, offset, scale, vertical);
       let iterations = 0;
-      const limit = 24;
+      const limit = 48;
 
-      while (iterations < limit && placed.some(rect => rectanglesOverlap(rect, candidate, layoutConfig.spacing))) {
-        if (offset < layoutConfig.maxOffset) {
-          offset += layoutConfig.step;
+      const intersectsExisting = rect => placed.some(existing => rectanglesOverlap(existing, rect, layoutConfig.verticalSpacing));
+
+      while (iterations < limit && intersectsExisting(candidate)) {
+        if (vertical < layoutConfig.maxVerticalOffset) {
+          vertical += layoutConfig.verticalStep;
+        } else if (offset < layoutConfig.maxOffset) {
+          offset += layoutConfig.stepX;
         } else if (scale > layoutConfig.minScale) {
           scale = Math.max(layoutConfig.minScale, scale - layoutConfig.scaleStep);
         } else {
-          offset += layoutConfig.step;
+          break;
         }
-        candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
+        candidate = computeAdjustedRect(item.rect, item.position, offset, scale, vertical);
         iterations += 1;
       }
 
       placed.push(candidate);
-      adjustments.push({ entry: item.entry, offset, scale });
+      adjustments.push({ entry: item.entry, offset, scale, vertical });
     });
 
     return adjustments;
-  }
-
-  function spreadYearLabels(entries) {
-    if (!entries.length) {
-      return new Map();
-    }
-
-    const nodes = entries
-      .map(entry => {
-        const year = entry.querySelector('.timeline-year');
-        if (!year) {
-          return null;
-        }
-        return { entry, rect: year.getBoundingClientRect() };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.rect.top - b.rect.top);
-
-    const offsets = new Map();
-    let lastBottom = -Infinity;
-
-    nodes.forEach(item => {
-      const desiredTop = Math.max(item.rect.top, lastBottom + layoutConfig.yearSpacing);
-      const offset = desiredTop - item.rect.top;
-      offsets.set(item.entry, offset);
-      lastBottom = desiredTop + item.rect.height;
-    });
-
-    return offsets;
   }
 
   function resetEntryLayout(section) {
@@ -391,38 +656,8 @@
     entries.querySelectorAll('.timeline-entry').forEach(entry => {
       entry.style.removeProperty('--bubble-offset');
       entry.style.removeProperty('--bubble-scale');
-      entry.style.removeProperty('--connector-length');
-      entry.style.removeProperty('--entry-y-offset');
-    });
-  }
-
-  function updateConnectorLengths(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
-      return;
-    }
-    const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
-      return;
-    }
-    const scaleElement = entries.querySelector('.timeline-century__scale');
-    const axisRect = scaleElement ? scaleElement.getBoundingClientRect() : null;
-    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-    entryNodes.forEach(entry => {
-      const bubble = entry.querySelector('.timeline-bubble');
-      if (!bubble) {
-        return;
-      }
-      const bubbleRect = bubble.getBoundingClientRect();
-      const targetNode = entry.querySelector('.timeline-year .timeline-node');
-      const targetRect = targetNode ? targetNode.getBoundingClientRect() : axisRect;
-      if (!targetRect) {
-        return;
-      }
-      const axisCenter = targetRect.left + targetRect.width / 2;
-      const distance = entry.dataset.position === 'left'
-        ? axisCenter - bubbleRect.right
-        : bubbleRect.left - axisCenter;
-      entry.style.setProperty('--connector-length', `${Math.max(distance, 0)}px`);
+      entry.style.removeProperty('--bubble-y-offset');
+      delete entry.dataset.verticalOffset;
     });
   }
 
@@ -441,21 +676,17 @@
         }
         const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
         const adjustments = resolveOverlaps(entryNodes);
-        const yearOffsets = spreadYearLabels(entryNodes);
 
-        adjustments.forEach(({ entry, offset, scale }) => {
+        adjustments.forEach(({ entry, offset, scale, vertical }) => {
           entry.style.setProperty('--bubble-offset', `${offset}px`);
           entry.style.setProperty('--bubble-scale', scale.toFixed(3));
-        });
-
-        entryNodes.forEach(entry => {
-          const yearOffset = yearOffsets.has(entry) ? yearOffsets.get(entry) : 0;
-          entry.style.setProperty('--entry-y-offset', `${yearOffset}px`);
+          entry.style.setProperty('--bubble-y-offset', `${vertical}px`);
+          entry.dataset.verticalOffset = String(vertical);
         });
       });
 
       requestAnimationFrame(() => {
-        sections.forEach(updateConnectorLengths);
+        sections.forEach(updateConnectors);
       });
     });
   }
@@ -501,8 +732,10 @@
     const bounds = normalizeCenturyBounds(century);
     entries.style.setProperty('--century-span', String(bounds.span || 100));
     buildCenturyScale(entries, bounds);
+    ensureWebGLBackground(entries);
+    ensureConnectorsElement(entries);
 
-    const events = Array.isArray(century.events) ? [...century.events] : [];
+    const events = ensurePhotoAlbumsForCentury(century, bounds);
     events.sort((a, b) => {
       const yearA = getEventYearValue(a, bounds);
       const yearB = getEventYearValue(b, bounds);
@@ -511,8 +744,9 @@
       }
       return yearA - yearB;
     });
+    const sideCounts = { left: 0, right: 0 };
     events.forEach(event => {
-      const entry = buildEvent(event, century, bounds);
+      const entry = buildEvent(event, century, bounds, sideCounts);
       entries.appendChild(entry);
     });
 
@@ -840,6 +1074,29 @@
     const evidenceSection = buildEvidenceSection(event);
     if (evidenceSection) {
       modalBody.appendChild(evidenceSection);
+    }
+
+    if (event.type === 'photo-album') {
+      const albumWrapper = document.createElement('div');
+      albumWrapper.className = 'modal-photo-album';
+
+      const placeholder = document.createElement('div');
+      placeholder.className = 'photo-album-placeholder';
+
+      const icon = document.createElement('div');
+      icon.className = 'photo-album-placeholder__icon';
+      icon.textContent = event.icon || '📸';
+      placeholder.appendChild(icon);
+
+      const text = document.createElement('p');
+      text.className = 'photo-album-placeholder__text';
+      const albumYear = event.albumYear || event.yearValue || event.year || '';
+      const readableYear = albumYear ? String(albumYear) : 'selected year';
+      text.textContent = `This space will showcase the ${readableYear} photo collection.`;
+      placeholder.appendChild(text);
+
+      albumWrapper.appendChild(placeholder);
+      modalBody.appendChild(albumWrapper);
     }
 
     modal.classList.add('active');


### PR DESCRIPTION
## Summary
- clamp the timeline container width and clip horizontal bleed so the viewport never scrolls sideways
- tune the bubble layout spacing to keep entries vertically separated while preserving their tethered connectors
- show only the configured event icons in bubbles to avoid duplicating the year label beside the decade ticks

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68ec039b522c832085b441a5ed13e394