### PR TITLE
Redesign timeline view with XMB navigation

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -32,6 +32,7 @@
       --entry-gap: 32px;
       --bubble-size: 60px;
       --year-scale: 7px;
+      --timeline-row-height: 184px;
     }
 
     body[data-theme='dark'] {
@@ -276,448 +277,256 @@
       gap: 0.5rem;
     }
 
-    .timeline {
-      position: relative;
-      max-width: 980px;
-      margin: 0 auto;
-      padding: 24px 0 64px;
-    }
-
-    .timeline::after {
-      content: '';
-      display: block;
-      height: 55vh;
-      max-height: 520px;
-    }
-
     .timeline-section {
-      padding-bottom: 20vh;
+      max-width: 1080px;
+      margin: 0 auto;
     }
 
-    .timeline-century + .timeline-century {
-      margin-top: 48px;
+    .timeline-xmb {
+      display: grid;
+      gap: 28px;
+      padding: 28px;
+      background: var(--surface);
+      border-radius: 24px;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
+      transition: background 0.3s ease, border 0.3s ease, box-shadow 0.3s ease;
     }
 
-    .timeline-century__header {
+    body[data-theme='dark'] .timeline-xmb {
+      background: rgba(15, 23, 42, 0.92);
+      border-color: rgba(96, 165, 250, 0.28);
+      box-shadow: 0 30px 56px -28px rgba(6, 12, 24, 0.85);
+    }
+
+    .timeline-xmb__years {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(180px, 1fr);
+      gap: 18px;
+      overflow-x: auto;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--surface-border);
+      scrollbar-width: thin;
+    }
+
+    .timeline-xmb__years::-webkit-scrollbar {
+      height: 8px;
+    }
+
+    .timeline-xmb__years::-webkit-scrollbar-thumb {
+      background: rgba(148, 163, 184, 0.4);
+      border-radius: 9999px;
+    }
+
+    body[data-theme='dark'] .timeline-xmb__years::-webkit-scrollbar-thumb {
+      background: rgba(96, 165, 250, 0.35);
+    }
+
+    .timeline-xmb__year-button {
+      position: relative;
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 12px;
-      text-align: center;
-      margin-bottom: 28px;
-    }
-
-    .timeline-century__heading {
-      font-size: 1.75rem;
-      font-weight: 700;
-      color: var(--heading-color);
-      margin: 0;
-    }
-
-    .timeline-century__heading-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      padding: 0.55rem 1.3rem;
-      border-radius: 9999px;
+      justify-content: center;
+      gap: 0.45rem;
+      padding: 18px 16px;
+      border-radius: 20px;
       border: 1px solid transparent;
-      background: transparent;
-      color: inherit;
-      font: inherit;
+      background: var(--surface-muted);
+      color: var(--heading-color);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      min-height: 124px;
       cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-      box-shadow: none;
-      position: relative;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease;
+      box-shadow: 0 18px 36px -26px rgba(15, 23, 42, 0.55);
     }
 
-    .timeline-century__heading-button::after {
-      content: '';
-      width: 10px;
-      height: 10px;
-      border-right: 2px solid currentColor;
-      border-bottom: 2px solid currentColor;
-      transform: rotate(45deg);
-      transition: transform 0.2s ease;
-    }
-
-    .timeline-century__heading-button[aria-expanded='false']::after {
-      transform: rotate(-45deg);
-    }
-
-    .timeline-century__heading-button:hover,
-    .timeline-century__heading-button:focus-visible {
-      background: var(--surface);
-      border-color: var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      transform: translateY(-1px);
+    .timeline-xmb__year-button:hover,
+    .timeline-xmb__year-button:focus-visible {
+      transform: translateY(-3px);
+      border-color: rgba(59, 130, 246, 0.45);
+      box-shadow: 0 24px 42px -24px rgba(37, 99, 235, 0.45);
       outline: none;
     }
 
-    body[data-theme='dark'] .timeline-century__heading-button {
+    body[data-theme='dark'] .timeline-xmb__year-button {
+      background: rgba(30, 41, 59, 0.85);
       color: var(--heading-color);
+      box-shadow: 0 22px 40px -26px rgba(6, 12, 24, 0.8);
     }
 
-    body[data-theme='dark'] .timeline-century__heading-button:hover,
-    body[data-theme='dark'] .timeline-century__heading-button:focus-visible {
-      background: rgba(15, 23, 42, 0.92);
-      border-color: rgba(96, 165, 250, 0.35);
+    .timeline-xmb__year-button--active {
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0.38));
+      border-color: rgba(37, 99, 235, 0.5);
+      box-shadow: 0 24px 48px -26px rgba(37, 99, 235, 0.55);
+      color: var(--accent-primary-strong);
     }
 
-    .timeline-century__summary {
-      max-width: 640px;
-      margin: 18px auto 0;
-      color: var(--text-muted);
-      font-style: italic;
+    body[data-theme='dark'] .timeline-xmb__year-button--active {
+      background: linear-gradient(135deg, rgba(96, 165, 250, 0.16), rgba(59, 130, 246, 0.38));
+      border-color: rgba(96, 165, 250, 0.55);
+      color: var(--accent-primary-strong);
+      box-shadow: 0 26px 52px -28px rgba(8, 47, 73, 0.75);
     }
 
-    .timeline-century__entries {
-      position: relative;
-      padding: 56px 0;
-      min-height: calc(var(--century-span, 100) * var(--year-scale));
-      margin-top: 32px;
-      overflow: visible;
+    .timeline-xmb__year-label {
+      font-size: 1rem;
+      letter-spacing: 0.06em;
     }
 
-    .timeline-century--collapsed .timeline-century__entries {
-      display: none;
+    .timeline-xmb__year-count {
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      color: var(--text-soft);
     }
 
-    .timeline-century__scale {
-      position: absolute;
-      inset: 0;
-      left: 50%;
-      width: var(--axis-column-width);
-      transform: translateX(-50%);
-      pointer-events: none;
+    .timeline-xmb__panel {
+      display: grid;
+      gap: 20px;
     }
 
-    .timeline-century__scale::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      left: 50%;
-      width: 2px;
-      transform: translateX(-50%);
-      background-image: repeating-linear-gradient(
-        to bottom,
-        rgba(59, 130, 246, 0.4) 0%,
-        rgba(59, 130, 246, 0.4) 2px,
-        transparent 2px,
-        transparent 12px
-      );
-    }
-
-    body[data-theme='dark'] .timeline-century__scale::before {
-      background-image: repeating-linear-gradient(
-        to bottom,
-        rgba(96, 165, 250, 0.55) 0%,
-        rgba(96, 165, 250, 0.55) 2px,
-        transparent 2px,
-        transparent 12px
-      );
-    }
-
-    .timeline-century__ticks {
-      position: absolute;
-      inset: 0;
-    }
-
-    .timeline-century__tick {
-      position: absolute;
-      left: 50%;
-      transform: translate(-50%, -50%);
+    .timeline-xmb__panel-header {
       display: flex;
       flex-direction: column;
-      align-items: center;
-      gap: 6px;
-      pointer-events: none;
-      z-index: 1;
+      gap: 0.35rem;
     }
 
-    .timeline-century__tick-label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      color: var(--heading-color);
-      background: var(--surface);
-      border: 1px solid var(--surface-border);
-      border-radius: 9999px;
-      padding: 2px 8px;
-      box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.65);
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-label {
-      color: var(--text-primary);
-      background: rgba(15, 23, 42, 0.92);
-      border-color: rgba(96, 165, 250, 0.35);
-      box-shadow: 0 18px 32px -28px rgba(6, 12, 24, 0.85);
-    }
-
-    .timeline-century__tick-mark {
-      position: relative;
-      display: block;
-      width: 6px;
-      height: 6px;
-      border-radius: 9999px;
-      background: rgba(37, 99, 235, 0.75);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-mark {
-      background: rgba(96, 165, 250, 0.8);
-      box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
-    }
-
-    .timeline-century__tick-mark::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      height: 1px;
-      background: rgba(37, 99, 235, 0.4);
-      width: 18px;
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-mark::after {
-      background: rgba(96, 165, 250, 0.45);
-    }
-
-    .timeline-century__tick--year .timeline-century__tick-mark::after {
-      width: 0;
-      height: 0;
-    }
-
-    .timeline-century__tick--quin .timeline-century__tick-mark {
-      width: 7px;
-      height: 7px;
-    }
-
-    .timeline-century__tick--quin .timeline-century__tick-mark::after {
-      width: 26px;
-      opacity: 0.5;
-    }
-
-    .timeline-century__tick--decade .timeline-century__tick-mark {
-      width: 9px;
-      height: 9px;
-    }
-
-    .timeline-century__tick--decade .timeline-century__tick-mark::after {
-      width: 38px;
-      height: 2px;
-      opacity: 0.7;
-    }
-
-    .timeline-century__tick--century .timeline-century__tick-mark {
-      width: 11px;
-      height: 11px;
-    }
-
-    .timeline-century__tick--century .timeline-century__tick-mark::after {
-      width: 52px;
-      height: 3px;
-      opacity: 0.95;
-    }
-
-    .timeline-entry {
-      position: absolute;
-      left: 0;
-      width: 100%;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) var(--axis-column-width) minmax(0, 1fr);
-      column-gap: var(--entry-gap);
-      align-items: center;
-      transform: translateY(calc(-50% + var(--entry-y-offset, 0px)));
-      z-index: 2;
-      --bubble-offset: 0px;
-      --bubble-scale: 1;
-      --connector-length: calc(var(--entry-gap) + var(--axis-column-width) / 2);
-    }
-
-    .timeline-entry__column {
-      display: flex;
-      align-items: center;
-      min-height: var(--bubble-size);
-    }
-
-    .timeline-entry__column--left {
-      justify-content: flex-end;
-    }
-
-    .timeline-entry__column--right {
-      justify-content: flex-start;
-    }
-
-    .timeline-entry__column--empty {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    .timeline-axis {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .timeline-node {
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.75rem 1rem;
-      border-radius: 9999px;
-      background: var(--surface);
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      color: var(--heading-color);
+    .timeline-xmb__panel-title {
+      margin: 0;
+      font-size: 2rem;
       font-weight: 700;
-      letter-spacing: 0.06em;
+      color: var(--heading-color);
+      letter-spacing: -0.01em;
+    }
+
+    .timeline-xmb__panel-meta {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      letter-spacing: 0.03em;
       text-transform: uppercase;
     }
 
-    body[data-theme='dark'] .timeline-node {
-      background: rgba(15, 23, 42, 0.92);
-      color: var(--heading-color);
+    .timeline-xmb__entries {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 14px;
     }
 
-    .timeline-node::before {
-      content: '';
-      position: absolute;
-      width: 18px;
-      height: 18px;
-      border-radius: 9999px;
-      background: rgba(59, 130, 246, 0.95);
-      box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.18);
-      z-index: -1;
-      opacity: 0.35;
+    .timeline-xmb__entry {
+      display: block;
     }
 
-    body[data-theme='dark'] .timeline-node::before {
-      background: rgba(96, 165, 250, 0.9);
+    .timeline-xmb__entry-button {
+      width: 100%;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      align-items: center;
+      gap: 18px;
+      padding: 18px 22px;
+      border-radius: 20px;
+      border: 1px solid rgba(59, 130, 246, 0.18);
+      background: var(--surface-muted);
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+      box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.55);
     }
 
-    .timeline-year {
-      position: relative;
-      z-index: 1;
+    .timeline-xmb__entry-button:hover,
+    .timeline-xmb__entry-button:focus-visible {
+      transform: translateX(6px);
+      border-color: rgba(37, 99, 235, 0.45);
+      box-shadow: 0 28px 48px -24px rgba(37, 99, 235, 0.55);
+      outline: none;
     }
 
-    .timeline-bubble {
-      width: var(--bubble-size);
-      height: var(--bubble-size);
-      border-radius: 9999px;
-      border: 2px solid var(--shared-border);
-      background: var(--shared-surface);
-      color: var(--heading-color);
+    body[data-theme='dark'] .timeline-xmb__entry-button {
+      background: rgba(15, 23, 42, 0.82);
+      border-color: rgba(96, 165, 250, 0.25);
+      box-shadow: 0 26px 46px -26px rgba(6, 12, 24, 0.82);
+    }
+
+    .timeline-xmb__entry-button--buckler {
+      border-color: rgba(16, 185, 129, 0.45);
+    }
+
+    .timeline-xmb__entry-button--bp {
+      border-color: rgba(248, 113, 113, 0.45);
+    }
+
+    .timeline-xmb__entry-button--both {
+      border-color: rgba(99, 102, 241, 0.4);
+    }
+
+    .timeline-xmb__entry-icon {
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-weight: 700;
-      font-size: 1.15rem;
-      position: relative;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      cursor: pointer;
-      transform: translateX(calc(var(--bubble-shift, 0px))) scale(var(--bubble-scale, 1));
-      transform-origin: center;
-    }
-
-    .timeline-bubble::before {
-      content: attr(data-title);
-      position: absolute;
-      bottom: calc(100% + 10px);
-      left: 50%;
-      transform: translate(-50%, 8px);
+      font-size: 1.75rem;
       background: var(--surface);
-      border-radius: 9999px;
-      border: 1px solid var(--surface-border);
-      padding: 0.4rem 0.75rem;
-      white-space: nowrap;
-      font-size: 0.85rem;
-      color: var(--text-primary);
-      box-shadow: var(--shadow-soft);
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.2s ease, transform 0.2s ease;
+      color: var(--heading-color);
+      box-shadow: 0 16px 26px -18px rgba(15, 23, 42, 0.55);
     }
 
-    .timeline-bubble:hover::before,
-    .timeline-bubble:focus-visible::before {
-      opacity: 1;
-      transform: translate(-50%, 0);
-    }
-
-    .timeline-bubble:hover,
-    .timeline-bubble:focus-visible {
-      transform: translateX(calc(var(--bubble-shift, 0px))) translateY(-3px) scale(var(--bubble-scale, 1));
-      box-shadow: 0 16px 32px -20px rgba(59, 130, 246, 0.45);
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after,
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      height: 2px;
-      transform: translateY(-50%);
-      pointer-events: none;
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after {
-      right: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.75) 0%,
-        rgba(59, 130, 246, 0.68) 74%,
-        rgba(59, 130, 246, 0.92) 100%
-      );
-    }
-
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      left: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.92) 0%,
-        rgba(59, 130, 246, 0.68) 26%,
-        rgba(59, 130, 246, 0.75) 100%
-      );
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble {
-      --bubble-shift: calc(-1 * var(--bubble-offset, 0px));
-    }
-
-    .timeline-entry[data-position='right'] .timeline-bubble {
-      --bubble-shift: var(--bubble-offset, 0px);
-    }
-
-    .timeline-bubble:focus-visible {
-      outline: 3px solid rgba(59, 130, 246, 0.4);
-      outline-offset: 4px;
-    }
-
-    .timeline-bubble--buckler {
+    .timeline-xmb__entry-button--buckler .timeline-xmb__entry-icon {
       background: var(--buckler-surface);
-      border-color: var(--buckler-border);
-      color: #065f46;
+      border: 1px solid var(--buckler-border);
     }
 
-    body[data-theme='dark'] .timeline-bubble--buckler {
-      color: var(--text-primary);
-    }
-
-    .timeline-bubble--bp {
+    .timeline-xmb__entry-button--bp .timeline-xmb__entry-icon {
       background: var(--bp-surface);
-      border-color: var(--bp-border);
-      color: #7f1d1d;
+      border: 1px solid var(--bp-border);
     }
 
-    body[data-theme='dark'] .timeline-bubble--bp {
-      color: var(--text-primary);
-    }
-
-    .timeline-bubble--both {
+    .timeline-xmb__entry-button--both .timeline-xmb__entry-icon {
       background: var(--shared-surface);
-      border-color: var(--shared-border);
+      border: 1px solid var(--shared-border);
+    }
+
+    .timeline-xmb__entry-text {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .timeline-xmb__entry-title {
+      font-weight: 700;
+      font-size: 1.05rem;
+      color: var(--heading-color);
+    }
+
+    .timeline-xmb__entry-summary {
+      color: var(--text-muted);
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+
+    .timeline-xmb__entry-chevron {
+      font-size: 1.8rem;
+      font-weight: 500;
+      color: var(--accent-primary-strong);
+    }
+
+    .timeline-xmb__empty {
+      padding: 18px 20px;
+      border-radius: 18px;
+      background: var(--surface-muted);
+      border: 1px solid var(--surface-border);
+      color: var(--text-soft);
+      text-align: center;
+      font-size: 0.95rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
     }
 
     .loading-text {
@@ -876,54 +685,39 @@
     }
 
     @media (max-width: 960px) {
-      :root {
-        --axis-column-width: 120px;
-        --entry-gap: 24px;
+      .timeline-xmb {
+        padding: 22px;
       }
 
-      .timeline-century__heading {
-        font-size: 1.5rem;
+      .timeline-xmb__years {
+        grid-auto-columns: minmax(150px, 1fr);
+      }
+
+      .timeline-xmb__panel-title {
+        font-size: 1.8rem;
       }
     }
 
     @media (max-width: 760px) {
-      :root {
-        --axis-column-width: 100px;
-        --entry-gap: 18px;
-        --bubble-size: 54px;
+      .timeline-xmb {
+        padding: 18px;
+        gap: 22px;
       }
 
-      .timeline {
-        padding-left: 12px;
-        padding-right: 12px;
+      .timeline-xmb__year-button {
+        min-height: 112px;
+        padding: 16px 14px;
       }
 
-      .timeline::before {
-        left: 22px;
+      .timeline-xmb__entry-button {
+        padding: 16px 18px;
+        gap: 16px;
       }
 
-      .timeline-entry {
-        grid-template-columns: var(--axis-column-width) 1fr;
-        column-gap: 16px;
-      }
-
-      .timeline-entry__column--left,
-      .timeline-entry__column--right {
-        grid-column: 2 / span 1;
-        justify-content: flex-start;
-      }
-
-      .timeline-entry[data-position='left'] .timeline-bubble::after,
-      .timeline-entry[data-position='right'] .timeline-bubble::after {
-        left: calc(-1 * (var(--axis-column-width) - 16px));
-        right: auto;
-        width: calc(var(--axis-column-width) - 12px);
-        background: linear-gradient(90deg, rgba(59, 130, 246, 0.65), rgba(59, 130, 246, 0));
-      }
-
-      .timeline-entry__column--left.timeline-entry__column--empty,
-      .timeline-entry__column--right.timeline-entry__column--empty {
-        display: none;
+      .timeline-xmb__entry-icon {
+        width: 46px;
+        height: 46px;
+        font-size: 1.5rem;
       }
     }
 
@@ -934,8 +728,35 @@
         font-size: 1.2rem;
       }
 
-      .timeline-bubble::before {
-        font-size: 0.8rem;
+      .timeline-xmb {
+        padding: 16px;
+      }
+
+      .timeline-xmb__years {
+        grid-auto-columns: minmax(130px, 1fr);
+        gap: 14px;
+      }
+
+      .timeline-xmb__year-label {
+        font-size: 0.92rem;
+      }
+
+      .timeline-xmb__panel-title {
+        font-size: 1.5rem;
+      }
+
+      .timeline-xmb__entry-button {
+        grid-template-columns: auto 1fr;
+        padding: 14px 16px;
+        gap: 14px;
+      }
+
+      .timeline-xmb__entry-chevron {
+        display: none;
+      }
+
+      .timeline-xmb__entry-summary {
+        font-size: 0.88rem;
       }
 
       .modal-content {
@@ -951,8 +772,7 @@
         <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
         <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
       </div>
-      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
-        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
+      <div id="timeline-controls" class="mt-8 flex flex-col items-center gap-3">
         <div class="controls-group">
           <div class="controls-group__buttons">
             <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
@@ -964,9 +784,6 @@
               <span class="sr-only">Toggle introduction</span>
             </button>
           </div>
-          <select id="century-select" class="century-select" disabled>
-            <option value="">Loading centuries…</option>
-          </select>
         </div>
       </div>
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
@@ -981,7 +798,16 @@
 
     <section class="mt-14 timeline-section">
       <div id="timeline-loading" class="text-center loading-text">Loading timeline data…</div>
-      <div class="timeline" id="timeline" aria-live="polite"></div>
+      <div class="timeline-xmb hidden" id="timeline" aria-live="polite">
+        <div class="timeline-xmb__years" id="timeline-year-bar" role="tablist" aria-label="Timeline years"></div>
+        <div class="timeline-xmb__panel">
+          <div class="timeline-xmb__panel-header">
+            <h2 id="timeline-year-title" class="timeline-xmb__panel-title">Select a year</h2>
+            <p id="timeline-year-meta" class="timeline-xmb__panel-meta hidden"></p>
+          </div>
+          <ul id="timeline-year-entries" class="timeline-xmb__entries" role="list"></ul>
+        </div>
+      </div>
     </section>
   </div>
 

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -9,9 +9,7 @@
   const caseSubtitle = document.getElementById('case-subtitle');
   const caseIntro = document.getElementById('case-intro');
   const keyThemes = document.getElementById('key-themes');
-  const centurySelector = document.getElementById('century-selector');
-  const centurySelect = document.getElementById('century-select');
-  const timelineContainer = document.getElementById('timeline');
+  const timelineRoot = document.getElementById('timeline');
   const loadingMessage = document.getElementById('timeline-loading');
   const modal = document.getElementById('modal');
   const closeBtn = modal ? modal.querySelector('.close-btn') : null;
@@ -20,11 +18,18 @@
   const modalDescription = document.getElementById('modal-description');
   const modalBody = document.getElementById('modal-body');
 
+  const yearBar = document.getElementById('timeline-year-bar');
+  const yearTitle = document.getElementById('timeline-year-title');
+  const yearMeta = document.getElementById('timeline-year-meta');
+  const yearEntries = document.getElementById('timeline-year-entries');
+
   const eventIndex = new Map();
   const storageKey = 'ghf-theme';
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-  let sharedSidePreference = 'right';
-  let centuriesData = [];
+
+  let yearGroups = [];
+  let yearGroupMap = new Map();
+  let activeYearKey = null;
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -40,7 +45,7 @@
       try {
         localStorage.setItem(storageKey, normalized);
       } catch (error) {
-        console.warn('Unable to persist theme preference', error);
+        // ignore persistence failures
       }
     }
   }
@@ -76,565 +81,333 @@
     }
   });
 
-  function choosePosition(event) {
-    if (event.side === 'buckler') {
-      return 'left';
-    }
-    if (event.side === 'bp') {
-      return 'right';
-    }
-    sharedSidePreference = sharedSidePreference === 'left' ? 'right' : 'left';
-    return sharedSidePreference;
-  }
-
-  function normalizeCenturyBounds(century) {
-    const start = Number(century?.startYear);
-    const end = Number(century?.endYear);
-    if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
-      return { startYear: start, endYear: end, span: Math.max(1, end - start) };
-    }
-    if (Number.isFinite(start)) {
-      const inferredEnd = start + 99;
-      return { startYear: start, endYear: inferredEnd, span: Math.max(1, inferredEnd - start) };
-    }
-    if (Number.isFinite(end)) {
-      const inferredStart = end - 99;
-      return { startYear: inferredStart, endYear: end, span: Math.max(1, end - inferredStart) };
-    }
-    return { startYear: 0, endYear: 99, span: 99 };
-  }
-
-  function getEventYearValue(event, bounds) {
-    if (!event) {
-      return bounds.endYear;
-    }
-    const direct = Number(event.yearValue);
+  function getEventYearValue(event) {
+    const direct = Number(event?.yearValue);
     if (Number.isFinite(direct)) {
       return direct;
     }
-    const match = typeof event.year === 'string' ? event.year.match(/(1[6-9]\d{2}|20\d{2})/) : null;
+    const match = typeof event?.year === 'string' ? event.year.match(/(1[0-9]{3}|20[0-9]{2})/) : null;
     if (match) {
       return Number(match[0]);
     }
-    return bounds.endYear;
+    return null;
   }
 
-  function positionForYear(year, bounds) {
-    const { startYear, endYear, span } = bounds;
-    if (!Number.isFinite(year)) {
-      return 0;
-    }
-    const clamped = Math.min(Math.max(year, startYear), endYear);
-    const offset = clamped - startYear;
-    const raw = (offset / span) * 100;
-    return Math.min(98, Math.max(2, raw));
+  function sanitizeKey(value, fallback) {
+    const base = String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return base || fallback;
   }
 
-  function buildCenturyScale(container, bounds) {
-    if (!container) {
-      return;
-    }
-    const scale = document.createElement('div');
-    scale.className = 'timeline-century__scale';
-
-    const ticks = document.createElement('div');
-    ticks.className = 'timeline-century__ticks';
-    scale.appendChild(ticks);
-
-    const { startYear, endYear, span } = bounds;
-    for (let year = startYear; year <= endYear; year += 1) {
-      const tick = document.createElement('div');
-      tick.className = 'timeline-century__tick timeline-century__tick--year';
-      if (year % 5 === 0) {
-        tick.classList.add('timeline-century__tick--quin');
-      }
-      if (year % 10 === 0) {
-        tick.classList.add('timeline-century__tick--decade');
-      }
-      if (year % 100 === 0) {
-        tick.classList.add('timeline-century__tick--century');
-      }
-
-      const offset = ((year - startYear) / span) * 100;
-      const position = Math.min(100, Math.max(0, offset));
-      tick.style.top = `${position}%`;
-
-      if (year % 10 === 0) {
-        const label = document.createElement('span');
-        label.className = 'timeline-century__tick-label';
-        label.textContent = String(year);
-        tick.appendChild(label);
-      }
-
-      const mark = document.createElement('span');
-      mark.className = 'timeline-century__tick-mark';
-      tick.appendChild(mark);
-
-      ticks.appendChild(tick);
-    }
-
-    container.prepend(scale);
-  }
-
-  function buildEvent(event, century, bounds) {
-    const position = choosePosition(event);
-    const entry = document.createElement('div');
-    entry.className = 'timeline-entry';
-    entry.dataset.position = position;
-    entry.dataset.eventId = event.id;
-
-    const eventYear = getEventYearValue(event, bounds);
-    const topPosition = positionForYear(eventYear, bounds);
-    entry.style.top = `${topPosition}%`;
-    entry.dataset.yearPosition = topPosition.toFixed(3);
-    if (Number.isFinite(eventYear)) {
-      entry.dataset.yearValue = String(eventYear);
-    }
-
-    const leftColumn = document.createElement('div');
-    leftColumn.className = 'timeline-entry__column timeline-entry__column--left';
-
-    const axisColumn = document.createElement('div');
-    axisColumn.className = 'timeline-axis';
-    axisColumn.setAttribute('aria-hidden', 'true');
-
-    const yearWrapper = document.createElement('div');
-    yearWrapper.className = 'timeline-year';
-    const node = document.createElement('div');
-    node.className = 'timeline-node';
-    const yearLabel = (event.year && String(event.year).trim()) || (Number.isFinite(eventYear) ? String(eventYear) : '');
-    node.textContent = yearLabel || '•';
-    yearWrapper.appendChild(node);
-    axisColumn.appendChild(yearWrapper);
-
-    const rightColumn = document.createElement('div');
-    rightColumn.className = 'timeline-entry__column timeline-entry__column--right';
-
-    const bubble = document.createElement('button');
-    bubble.className = `timeline-bubble timeline-bubble--${event.side || 'both'}`;
-    bubble.type = 'button';
-    bubble.dataset.eventId = event.id;
-    bubble.dataset.title = event.title;
-
-    const bubbleYear = (() => {
-      if (Number.isFinite(eventYear)) {
-        return Math.round(eventYear);
-      }
-      const match = typeof event.year === 'string' ? event.year.match(/(1[5-9]\d{2}|20\d{2})/) : null;
-      if (match) {
-        return Number(match[0]);
-      }
-      const fallbackMatch = typeof event.label === 'string' ? event.label.match(/(1[5-9]\d{2}|20\d{2})/) : null;
-      return fallbackMatch ? Number(fallbackMatch[0]) : null;
-    })();
-
-    const bubbleIcon = typeof event.icon === 'string' && event.icon.trim().length ? event.icon.trim() : null;
-    const bubbleLabel = bubbleIcon || (bubbleYear != null ? String(bubbleYear).padStart(4, '0') : (event.year ? String(event.year) : (event.label || '•')));
-    const bubbleIconLabel = typeof event.iconLabel === 'string' && event.iconLabel.trim().length ? event.iconLabel.trim() : null;
-
-    const accessibilityLabelParts = [event.title];
-    if (bubbleIconLabel) {
-      accessibilityLabelParts.push(bubbleIconLabel);
-    }
-    if (bubbleYear != null) {
-      accessibilityLabelParts.push(String(bubbleYear));
-    } else if (event.year) {
-      accessibilityLabelParts.push(String(event.year));
-    }
-
-    const accessibilityLabel = accessibilityLabelParts.join(' – ');
-
-    bubble.setAttribute('aria-label', accessibilityLabel);
-    bubble.setAttribute('title', accessibilityLabel);
-    bubble.textContent = bubbleLabel;
-    bubble.addEventListener('click', () => openEvent(event.id));
-    bubble.addEventListener('keydown', eventKey => {
-      if (eventKey.key === 'Enter' || eventKey.key === ' ') {
-        eventKey.preventDefault();
-        openEvent(event.id);
-      }
-    });
-
-    if (position === 'left') {
-      leftColumn.appendChild(bubble);
-      rightColumn.classList.add('timeline-entry__column--empty');
-    } else {
-      rightColumn.appendChild(bubble);
-      leftColumn.classList.add('timeline-entry__column--empty');
-    }
-
-    entry.appendChild(leftColumn);
-    entry.appendChild(axisColumn);
-    entry.appendChild(rightColumn);
-
-    eventIndex.set(event.id, { event, century });
-    return entry;
-  }
-
-  const layoutConfig = {
-    step: 28,
-    maxOffset: 180,
-    minScale: 0.65,
-    scaleStep: 0.08,
-    spacing: 14,
-    yearSpacing: 12,
-  };
-
-  let layoutFrame = null;
-
-  function computeAdjustedRect(rect, position, offset, scale) {
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-    const shift = position === 'left' ? -offset : offset;
-    const width = rect.width * scale;
-    const height = rect.height * scale;
-    const left = centerX + shift - width / 2;
-    const top = centerY - height / 2;
-    return {
-      left,
-      right: left + width,
-      top,
-      bottom: top + height,
-    };
-  }
-
-  function rectanglesOverlap(a, b, spacing) {
-    const verticalOverlap = a.bottom > b.top - spacing && a.top < b.bottom + spacing;
-    const horizontalOverlap = a.right > b.left - spacing && a.left < b.right + spacing;
-    return verticalOverlap && horizontalOverlap;
-  }
-
-  function resolveOverlaps(entries) {
-    if (!entries.length) {
+  function buildYearGroups(data) {
+    eventIndex.clear();
+    const groups = new Map();
+    if (!Array.isArray(data?.centuries)) {
       return [];
     }
-    const data = entries
-      .map(entry => {
-        const bubble = entry.querySelector('.timeline-bubble');
-        if (!bubble) {
-          return null;
-        }
-        const rect = bubble.getBoundingClientRect();
-        const position = entry.dataset.position === 'left' ? 'left' : 'right';
-        return { entry, bubble, rect, position };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.rect.top - b.rect.top);
 
-    const placements = { left: [], right: [] };
-    const adjustments = [];
-
-    data.forEach(item => {
-      const placed = placements[item.position];
-      let offset = 0;
-      let scale = 1;
-      let candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
-      let iterations = 0;
-      const limit = 24;
-
-      while (iterations < limit && placed.some(rect => rectanglesOverlap(rect, candidate, layoutConfig.spacing))) {
-        if (offset < layoutConfig.maxOffset) {
-          offset += layoutConfig.step;
-        } else if (scale > layoutConfig.minScale) {
-          scale = Math.max(layoutConfig.minScale, scale - layoutConfig.scaleStep);
-        } else {
-          offset += layoutConfig.step;
-        }
-        candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
-        iterations += 1;
-      }
-
-      placed.push(candidate);
-      adjustments.push({ entry: item.entry, offset, scale });
-    });
-
-    return adjustments;
-  }
-
-  function spreadYearLabels(entries) {
-    if (!entries.length) {
-      return new Map();
-    }
-
-    const nodes = entries
-      .map(entry => {
-        const year = entry.querySelector('.timeline-year');
-        if (!year) {
-          return null;
-        }
-        return { entry, rect: year.getBoundingClientRect() };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.rect.top - b.rect.top);
-
-    const offsets = new Map();
-    let lastBottom = -Infinity;
-
-    nodes.forEach(item => {
-      const desiredTop = Math.max(item.rect.top, lastBottom + layoutConfig.yearSpacing);
-      const offset = desiredTop - item.rect.top;
-      offsets.set(item.entry, offset);
-      lastBottom = desiredTop + item.rect.height;
-    });
-
-    return offsets;
-  }
-
-  function resetEntryLayout(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
-      return;
-    }
-    const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
-      return;
-    }
-    entries.querySelectorAll('.timeline-entry').forEach(entry => {
-      entry.style.removeProperty('--bubble-offset');
-      entry.style.removeProperty('--bubble-scale');
-      entry.style.removeProperty('--connector-length');
-      entry.style.removeProperty('--entry-y-offset');
-    });
-  }
-
-  function updateConnectorLengths(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
-      return;
-    }
-    const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
-      return;
-    }
-    const scaleElement = entries.querySelector('.timeline-century__scale');
-    const axisRect = scaleElement ? scaleElement.getBoundingClientRect() : null;
-    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-    entryNodes.forEach(entry => {
-      const bubble = entry.querySelector('.timeline-bubble');
-      if (!bubble) {
-        return;
-      }
-      const bubbleRect = bubble.getBoundingClientRect();
-      const targetNode = entry.querySelector('.timeline-year .timeline-node');
-      const targetRect = targetNode ? targetNode.getBoundingClientRect() : axisRect;
-      if (!targetRect) {
-        return;
-      }
-      const axisCenter = targetRect.left + targetRect.width / 2;
-      const distance = entry.dataset.position === 'left'
-        ? axisCenter - bubbleRect.right
-        : bubbleRect.left - axisCenter;
-      entry.style.setProperty('--connector-length', `${Math.max(distance, 0)}px`);
-    });
-  }
-
-  function applyLayout() {
-    const sections = Array.from(timelineContainer.querySelectorAll('.timeline-century'));
-    sections.forEach(resetEntryLayout);
-
-    requestAnimationFrame(() => {
-      sections.forEach(section => {
-        if (section.classList.contains('timeline-century--collapsed')) {
+    data.centuries.forEach((century, centuryIndex) => {
+      const events = Array.isArray(century?.events) ? century.events : [];
+      events.forEach((event, eventIndexInCentury) => {
+        if (!event || !event.id) {
           return;
         }
-        const entries = section.querySelector('.timeline-century__entries');
-        if (!entries || entries.hidden) {
-          return;
+        const label = (typeof event.year === 'string' && event.year.trim()) || 'Undated';
+        const normalized = label.toLowerCase();
+        const sortValue = getEventYearValue(event);
+        if (!groups.has(normalized)) {
+          groups.set(normalized, {
+            label,
+            normalized,
+            sortValue: Number.isFinite(sortValue) ? sortValue : null,
+            events: [],
+            centuries: [],
+          });
         }
-        const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-        const adjustments = resolveOverlaps(entryNodes);
-        const yearOffsets = spreadYearLabels(entryNodes);
-
-        adjustments.forEach(({ entry, offset, scale }) => {
-          entry.style.setProperty('--bubble-offset', `${offset}px`);
-          entry.style.setProperty('--bubble-scale', scale.toFixed(3));
+        const group = groups.get(normalized);
+        if (Number.isFinite(sortValue)) {
+          if (!Number.isFinite(group.sortValue) || sortValue < group.sortValue) {
+            group.sortValue = sortValue;
+          }
+        }
+        group.events.push({
+          event,
+          century,
+          index: eventIndexInCentury,
         });
-
-        entryNodes.forEach(entry => {
-          const yearOffset = yearOffsets.has(entry) ? yearOffsets.get(entry) : 0;
-          entry.style.setProperty('--entry-y-offset', `${yearOffset}px`);
-        });
-      });
-
-      requestAnimationFrame(() => {
-        sections.forEach(updateConnectorLengths);
+        if (century) {
+          const signature = `${century.title || ''}__${century.range || ''}`;
+          if (!group.centuries.some(entry => entry.signature === signature)) {
+            group.centuries.push({
+              signature,
+              title: century.title || '',
+              range: century.range || '',
+            });
+          }
+        }
+        eventIndex.set(event.id, { event, century });
       });
     });
-  }
 
-  function scheduleLayout() {
-    if (layoutFrame) {
-      cancelAnimationFrame(layoutFrame);
-    }
-    layoutFrame = requestAnimationFrame(() => {
-      layoutFrame = null;
-      applyLayout();
-    });
-  }
-
-  function buildCenturySection(century, index) {
-    const section = document.createElement('section');
-    section.className = 'timeline-century';
-
-    const header = document.createElement('div');
-    header.className = 'timeline-century__header';
-
-    const heading = document.createElement('h2');
-    heading.className = 'timeline-century__heading';
-    const headingText = century.title || 'Century of occupation';
-    heading.textContent = century.range ? `${headingText} (${century.range})` : headingText;
-    header.appendChild(heading);
-
-    section.appendChild(header);
-
-    if (century.summary) {
-      const summary = document.createElement('p');
-      summary.className = 'timeline-century__summary';
-      summary.textContent = century.summary;
-      section.appendChild(summary);
-    }
-
-    const entries = document.createElement('div');
-    entries.className = 'timeline-century__entries';
-    const idSeed = (century.id || `century-${index + 1}`).toString();
-    const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-    entries.id = `${normalizedId || `century-${index + 1}`}-entries`;
-
-    const bounds = normalizeCenturyBounds(century);
-    entries.style.setProperty('--century-span', String(bounds.span || 100));
-    buildCenturyScale(entries, bounds);
-
-    const events = Array.isArray(century.events) ? [...century.events] : [];
-    events.sort((a, b) => {
-      const yearA = getEventYearValue(a, bounds);
-      const yearB = getEventYearValue(b, bounds);
-      if (yearA === yearB) {
-        return (a.label || a.id || '').localeCompare(b.label || b.id || '');
+    const result = Array.from(groups.values());
+    result.sort((a, b) => {
+      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.POSITIVE_INFINITY;
+      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.POSITIVE_INFINITY;
+      if (aValue !== bValue) {
+        return aValue - bValue;
       }
-      return yearA - yearB;
-    });
-    events.forEach(event => {
-      const entry = buildEvent(event, century, bounds);
-      entries.appendChild(entry);
+      return a.label.localeCompare(b.label, undefined, { numeric: true });
     });
 
-    section.appendChild(entries);
-    return section;
+    const usedKeys = new Set();
+    result.forEach((group, index) => {
+      const baseKey = sanitizeKey(group.label, `year-${index + 1}`);
+      let candidate = baseKey;
+      let attempt = 2;
+      while (usedKeys.has(candidate)) {
+        candidate = `${baseKey}-${attempt}`;
+        attempt += 1;
+      }
+      group.key = candidate;
+      usedKeys.add(candidate);
+      group.events.sort((a, b) => {
+        const aSort = getEventYearValue(a.event);
+        const bSort = getEventYearValue(b.event);
+        if (Number.isFinite(aSort) && Number.isFinite(bSort) && aSort !== bSort) {
+          return aSort - bSort;
+        }
+        return a.index - b.index;
+      });
+    });
+
+    return result;
+  }
+
+  function updateYearMeta(group) {
+    if (!yearMeta) {
+      return;
+    }
+    if (!group || !group.centuries.length) {
+      yearMeta.textContent = '';
+      yearMeta.classList.add('hidden');
+      return;
+    }
+    const descriptors = group.centuries
+      .map(entry => {
+        if (entry.title && entry.range) {
+          return `${entry.title} (${entry.range})`;
+        }
+        return entry.title || entry.range;
+      })
+      .filter(Boolean);
+    if (descriptors.length) {
+      yearMeta.textContent = descriptors.join(' • ');
+      yearMeta.classList.remove('hidden');
+    } else {
+      yearMeta.textContent = '';
+      yearMeta.classList.add('hidden');
+    }
+  }
+
+  function renderYearEntries(group) {
+    if (!yearEntries) {
+      return;
+    }
+    yearEntries.innerHTML = '';
+    if (!group || !group.events.length) {
+      const empty = document.createElement('li');
+      empty.className = 'timeline-xmb__empty';
+      empty.textContent = 'No entries recorded for this year.';
+      yearEntries.appendChild(empty);
+      return;
+    }
+
+    group.events.forEach(record => {
+      const li = document.createElement('li');
+      li.className = 'timeline-xmb__entry';
+
+      const button = document.createElement('button');
+      const side = record.event.side || 'both';
+      button.type = 'button';
+      button.className = `timeline-xmb__entry-button timeline-xmb__entry-button--${side}`;
+      button.dataset.eventId = record.event.id;
+      button.addEventListener('click', () => openEvent(record.event.id));
+
+      const icon = document.createElement('span');
+      icon.className = 'timeline-xmb__entry-icon';
+      const iconSymbol = typeof record.event.icon === 'string' && record.event.icon.trim()
+        ? record.event.icon.trim()
+        : '•';
+      icon.textContent = iconSymbol;
+      if (record.event.iconLabel) {
+        icon.setAttribute('role', 'img');
+        icon.setAttribute('aria-label', record.event.iconLabel);
+        icon.setAttribute('title', record.event.iconLabel);
+      } else {
+        icon.setAttribute('aria-hidden', 'true');
+      }
+
+      const textWrapper = document.createElement('span');
+      textWrapper.className = 'timeline-xmb__entry-text';
+
+      const title = document.createElement('span');
+      title.className = 'timeline-xmb__entry-title';
+      title.textContent = record.event.title;
+      textWrapper.appendChild(title);
+
+      if (record.event.summary) {
+        const summary = document.createElement('span');
+        summary.className = 'timeline-xmb__entry-summary';
+        summary.textContent = record.event.summary;
+        textWrapper.appendChild(summary);
+      }
+
+      const chevron = document.createElement('span');
+      chevron.className = 'timeline-xmb__entry-chevron';
+      chevron.setAttribute('aria-hidden', 'true');
+      chevron.textContent = '›';
+
+      button.appendChild(icon);
+      button.appendChild(textWrapper);
+      button.appendChild(chevron);
+
+      li.appendChild(button);
+      yearEntries.appendChild(li);
+    });
+  }
+
+  function updateYearBarActive() {
+    if (!yearBar) {
+      return;
+    }
+    const buttons = yearBar.querySelectorAll('[data-year-key]');
+    buttons.forEach(button => {
+      const isActive = button.dataset.yearKey === activeYearKey;
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.classList.toggle('timeline-xmb__year-button--active', isActive);
+    });
+  }
+
+  function updateUrlWithYear(key) {
+    try {
+      const url = new URL(window.location.href);
+      if (key) {
+        url.searchParams.set('year', key);
+      } else {
+        url.searchParams.delete('year');
+      }
+      window.history.replaceState(null, '', url);
+    } catch (error) {
+      // ignore URL update issues
+    }
+  }
+
+  function activateYear(key, options = {}) {
+    if (!key || !yearGroupMap.has(key)) {
+      return;
+    }
+    const group = yearGroupMap.get(key);
+    activeYearKey = key;
+    if (yearTitle) {
+      yearTitle.textContent = group.label;
+    }
+    updateYearMeta(group);
+    renderYearEntries(group);
+    updateYearBarActive();
+
+    const shouldScroll = Boolean(options.scroll);
+    const shouldFocus = Boolean(options.focus);
+    if ((shouldScroll || shouldFocus) && yearBar) {
+      const button = yearBar.querySelector(`[data-year-key='${key}']`);
+      if (button) {
+        if (shouldFocus) {
+          button.focus({ preventScroll: true });
+        }
+        if (shouldScroll) {
+          const barRect = yearBar.getBoundingClientRect();
+          const buttonRect = button.getBoundingClientRect();
+          if (buttonRect.left < barRect.left) {
+            button.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
+          } else if (buttonRect.right > barRect.right) {
+            button.scrollIntoView({ behavior: 'smooth', inline: 'end', block: 'nearest' });
+          }
+        }
+      }
+    }
+
+    updateUrlWithYear(key);
+  }
+
+  function renderYearBar() {
+    if (!yearBar) {
+      return;
+    }
+    yearBar.innerHTML = '';
+    yearGroups.forEach(group => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'timeline-xmb__year-button';
+      button.dataset.yearKey = group.key;
+      button.setAttribute('aria-pressed', 'false');
+
+      const label = document.createElement('span');
+      label.className = 'timeline-xmb__year-label';
+      label.textContent = group.label;
+      button.appendChild(label);
+
+      const count = document.createElement('span');
+      count.className = 'timeline-xmb__year-count';
+      count.textContent = `${group.events.length} ${group.events.length === 1 ? 'entry' : 'entries'}`;
+      button.appendChild(count);
+
+      button.addEventListener('click', () => {
+        activateYear(group.key, { scroll: true });
+      });
+
+      yearBar.appendChild(button);
+    });
   }
 
   function showEmptyTimelineState() {
-    timelineContainer.innerHTML = '';
-    const empty = document.createElement('p');
-    empty.className = 'text-center text-slate-500 dark:text-slate-300';
-    empty.textContent = 'No timeline entries available.';
-    timelineContainer.appendChild(empty);
-  }
-
-  function displayCentury(value) {
-    if (!Array.isArray(centuriesData) || !centuriesData.length) {
-      showEmptyTimelineState();
-      return;
+    if (timelineRoot) {
+      timelineRoot.classList.add('hidden');
     }
-
-    let record = centuriesData.find(entry => entry.value === value);
-    if (!record) {
-      [record] = centuriesData;
-      if (!record) {
-        showEmptyTimelineState();
-        return;
-      }
-      if (centurySelect) {
-        centurySelect.value = record.value;
-      }
+    if (loadingMessage) {
+      loadingMessage.classList.remove('hidden');
+      loadingMessage.textContent = 'No timeline entries available.';
     }
-
-    timelineContainer.innerHTML = '';
-    eventIndex.clear();
-    sharedSidePreference = 'right';
-
-    const section = buildCenturySection(record.century, record.index);
-    timelineContainer.appendChild(section);
-    scheduleLayout();
   }
 
   function renderTimeline(data) {
-    const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
-    centuriesData = centuries.map((century, index) => {
-      const idSeed = (century.id || `century-${index + 1}`).toString();
-      const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      return {
-        century,
-        index,
-        value: normalizedId || `century-${index + 1}`,
-      };
-    });
-
-    if (centurySelect) {
-      centurySelect.innerHTML = '';
-      if (!centuriesData.length) {
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = 'No centuries available';
-        centurySelect.appendChild(option);
-        centurySelect.disabled = true;
-      } else {
-        centuriesData.forEach(entry => {
-          const option = document.createElement('option');
-          option.value = entry.value;
-          const title = entry.century.title || entry.century.range || `Century ${entry.index + 1}`;
-          if (entry.century.title && entry.century.range) {
-            option.textContent = `${entry.century.title} (${entry.century.range})`;
-          } else {
-            option.textContent = title;
-          }
-          centurySelect.appendChild(option);
-        });
-        centurySelect.disabled = centuriesData.length <= 1;
-      }
-
-      if (centurySelector) {
-        centurySelector.classList.toggle('hidden', !centuriesData.length);
-      }
-
-      centurySelect.onchange = event => {
-        const { value } = event.target;
-        displayCentury(value);
-        try {
-          const url = new URL(window.location.href);
-          if (value) {
-            url.searchParams.set('century', value);
-          } else {
-            url.searchParams.delete('century');
-          }
-          window.history.replaceState(null, '', url);
-        } catch (error) {
-          // ignore URL update issues
-        }
-      };
-    }
-
-    if (!centuriesData.length) {
+    yearGroups = buildYearGroups(data);
+    yearGroupMap = new Map(yearGroups.map(group => [group.key, group]));
+    if (!yearGroups.length) {
       showEmptyTimelineState();
       return;
     }
 
-    let defaultCentury = centuriesData[0];
+    if (loadingMessage) {
+      loadingMessage.classList.add('hidden');
+    }
+    if (timelineRoot) {
+      timelineRoot.classList.remove('hidden');
+    }
+
+    renderYearBar();
+    let defaultKey = yearGroups[0].key;
     try {
       const url = new URL(window.location.href);
-      const searchCentury = url.searchParams.get('century');
-      const hashCentury = window.location.hash ? window.location.hash.replace(/^#/, '') : '';
-      const requested = searchCentury || hashCentury || '';
-      if (requested) {
-        const found = centuriesData.find(entry => entry.value === requested);
-        if (found) {
-          defaultCentury = found;
-        }
+      const requested = url.searchParams.get('year') || (window.location.hash ? window.location.hash.replace(/^#/, '') : '');
+      if (requested && yearGroupMap.has(requested)) {
+        defaultKey = requested;
       }
     } catch (error) {
-      // ignore URL parsing issues
+      // ignore URL issues
     }
-    if (centurySelect) {
-      centurySelect.value = defaultCentury.value;
-    }
-    displayCentury(defaultCentury.value);
+
+    activateYear(defaultKey);
   }
 
   function renderIntro(data) {
@@ -899,19 +672,29 @@
     introClose.addEventListener('click', () => updateIntroState(false));
   }
 
-  const handleWindowResize = () => scheduleLayout();
-  window.addEventListener('resize', handleWindowResize);
-  window.addEventListener('orientationchange', handleWindowResize);
-
-  const timelineLayoutObserver = typeof ResizeObserver !== 'undefined' && timelineContainer
-    ? new ResizeObserver(() => scheduleLayout())
-    : null;
-  if (timelineLayoutObserver) {
-    timelineLayoutObserver.observe(timelineContainer);
-  }
-
-  if (document.fonts && document.fonts.ready) {
-    document.fonts.ready.then(() => scheduleLayout());
+  if (yearBar) {
+    yearBar.addEventListener('keydown', event => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+        return;
+      }
+      const buttons = Array.from(yearBar.querySelectorAll('[data-year-key]'));
+      if (!buttons.length) {
+        return;
+      }
+      const currentIndex = buttons.findIndex(button => button.dataset.yearKey === activeYearKey);
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowLeft') {
+        nextIndex = currentIndex <= 0 ? buttons.length - 1 : currentIndex - 1;
+      } else if (event.key === 'ArrowRight') {
+        nextIndex = currentIndex >= buttons.length - 1 ? 0 : currentIndex + 1;
+      }
+      const nextButton = buttons[nextIndex];
+      if (nextButton) {
+        event.preventDefault();
+        const { yearKey } = nextButton.dataset;
+        activateYear(yearKey, { scroll: true, focus: true });
+      }
+    });
   }
 
   fetch('data/timeline.json')
@@ -922,13 +705,14 @@
       return response.json();
     })
     .then(data => {
-      loadingMessage.classList.add('hidden');
       renderIntro(data);
       renderTimeline(data);
     })
     .catch(error => {
       console.error(error);
-      loadingMessage.textContent = 'We could not load the timeline data. Please refresh the page.';
+      if (loadingMessage) {
+        loadingMessage.classList.remove('hidden');
+        loadingMessage.textContent = 'We could not load the timeline data. Please refresh the page.';
+      }
     });
 })();
-


### PR DESCRIPTION
## Summary
- restyle the timeline into an XMB-inspired layout with a horizontal year bar and vertical entry list, including responsive tweaks
- rebuild the timeline script to group events by year, drive the new navigation, and preserve the modal experience
- simplify the controls header to keep only the theme and introduction toggles

## Testing
- Manual verification of static/bpvsbuckler/index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68ef0f43c7b48320bfee2f4f3eab4e34