### PR TITLE
Rebuild timeline with XMB-style navigation

### DIFF
--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -332,14 +332,35 @@ body[data-theme='dark'] .detail-card {
 }
 
 .detail-back-link {
+  position: fixed;
+  top: clamp(18px, 5vw, 32px);
+  left: clamp(18px, 5vw, 32px);
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 2.5rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: clamp(0.65rem, 2vw, 0.9rem) clamp(1.1rem, 4vw, 1.6rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--accent-primary-strong);
+  font-size: clamp(0.9rem, 1.8vw, 1.1rem);
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-primary-strong));
+  color: #fff;
+  border-radius: 999px;
+  box-shadow: var(--shadow-strong);
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  z-index: 20;
+}
+
+.detail-back-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 48px -24px rgba(37, 99, 235, 0.45);
+}
+
+.detail-back-link:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 4px;
 }
 
 body[data-theme='dark'] .detail-evidence-item {
@@ -347,7 +368,8 @@ body[data-theme='dark'] .detail-evidence-item {
 }
 
 body[data-theme='dark'] .detail-back-link {
-  color: var(--accent-primary-strong);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(59, 130, 246, 0.8));
+  color: #0f172a;
 }
 
 @media (max-width: 768px) {

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -8,994 +8,490 @@
   <style>
     :root {
       color-scheme: light;
-      --page-background: #f3f4f6;
-      --surface: rgba(255, 255, 255, 0.94);
-      --surface-muted: rgba(255, 255, 255, 0.82);
-      --surface-border: rgba(59, 130, 246, 0.16);
+      --page-background: #0f172a;
+      --surface: rgba(15, 23, 42, 0.7);
+      --surface-strong: rgba(15, 23, 42, 0.9);
+      --surface-muted: rgba(15, 23, 42, 0.6);
+      --surface-border: rgba(148, 163, 184, 0.2);
+      --heading-color: #f8fafc;
+      --text-primary: #e2e8f0;
+      --text-muted: rgba(226, 232, 240, 0.75);
+      --accent: #38bdf8;
+      --accent-soft: rgba(56, 189, 248, 0.2);
+      --accent-strong: #0ea5e9;
+      --shadow-soft: 0 30px 80px -40px rgba(15, 23, 42, 0.8);
+      --shadow-strong: 0 40px 120px -60px rgba(14, 165, 233, 0.4);
+      --bottom-band-height: clamp(240px, 33vh, 360px);
+      --horizontal-gap: clamp(18px, 4vw, 36px);
+      --horizontal-padding: clamp(54px, 6vw, 112px);
+      --vertical-gap: clamp(16px, 2.8vh, 28px);
+    }
+
+    body[data-theme='light'] {
+      color-scheme: light;
+      --page-background: #f1f5f9;
+      --surface: rgba(255, 255, 255, 0.72);
+      --surface-strong: rgba(255, 255, 255, 0.92);
+      --surface-muted: rgba(255, 255, 255, 0.6);
+      --surface-border: rgba(148, 163, 184, 0.18);
       --heading-color: #0f172a;
-      --text-primary: #1f2937;
-      --text-muted: rgba(17, 24, 39, 0.75);
-      --text-soft: rgba(17, 24, 39, 0.6);
-      --accent-primary: #2563eb;
-      --accent-primary-strong: #1e3a8a;
-      --accent-muted: rgba(59, 130, 246, 0.18);
-      --buckler-surface: linear-gradient(135deg, #d1fae5, #ecfdf5);
-      --buckler-border: #10b981;
-      --bp-surface: linear-gradient(135deg, #fee2e2, #fff1f2);
-      --bp-border: #ef4444;
-      --shared-surface: linear-gradient(135deg, #e0e7ff, #eef2ff);
-      --shared-border: #4338ca;
-      --shadow-soft: 0 22px 36px -24px rgba(15, 23, 42, 0.55);
-      --shadow-strong: 0 30px 52px -32px rgba(15, 23, 42, 0.65);
-      --modal-backdrop: rgba(15, 23, 42, 0.55);
-      --axis-column-width: 150px;
-      --entry-gap: 32px;
-      --bubble-size: 60px;
-      --year-scale: 7px;
+      --text-primary: #1e293b;
+      --text-muted: rgba(30, 41, 59, 0.7);
+      --accent: #2563eb;
+      --accent-soft: rgba(37, 99, 235, 0.12);
+      --accent-strong: #1d4ed8;
+      --shadow-soft: 0 30px 80px -48px rgba(15, 23, 42, 0.25);
+      --shadow-strong: 0 40px 120px -60px rgba(37, 99, 235, 0.35);
     }
 
     body[data-theme='dark'] {
       color-scheme: dark;
-      --page-background: #060b16;
-      --surface: rgba(15, 23, 42, 0.9);
-      --surface-muted: rgba(30, 41, 59, 0.82);
-      --surface-border: rgba(96, 165, 250, 0.28);
-      --heading-color: #e2e8f0;
-      --text-primary: #e2e8f0;
-      --text-muted: rgba(203, 213, 225, 0.85);
-      --text-soft: rgba(148, 163, 184, 0.8);
-      --accent-primary: #60a5fa;
-      --accent-primary-strong: #bfdbfe;
-      --accent-muted: rgba(96, 165, 250, 0.32);
-      --buckler-surface: linear-gradient(135deg, rgba(34, 197, 94, 0.25), rgba(16, 185, 129, 0.1));
-      --buckler-border: rgba(34, 197, 94, 0.75);
-      --bp-surface: linear-gradient(135deg, rgba(248, 113, 113, 0.25), rgba(248, 113, 113, 0.1));
-      --bp-border: rgba(248, 113, 113, 0.75);
-      --shared-surface: linear-gradient(135deg, rgba(96, 165, 250, 0.25), rgba(129, 140, 248, 0.1));
-      --shared-border: rgba(129, 140, 248, 0.85);
-      --shadow-soft: 0 24px 44px -26px rgba(8, 47, 73, 0.7);
-      --shadow-strong: 0 34px 56px -30px rgba(8, 47, 73, 0.85);
-      --modal-backdrop: rgba(6, 12, 24, 0.75);
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    .hidden {
+      display: none !important;
     }
 
     body {
-      background: var(--page-background);
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 42%),
+        radial-gradient(circle at top right, rgba(14, 165, 233, 0.24), transparent 48%),
+        var(--page-background);
       color: var(--text-primary);
-      transition: background 0.3s ease, color 0.3s ease;
+      min-height: 100vh;
+      overflow-x: hidden;
     }
 
     a {
-      color: var(--accent-primary);
+      color: inherit;
+      text-decoration: none;
     }
 
-    .page-title {
+    a:focus-visible,
+    button:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 4px;
+    }
+
+    .timeline-app {
+      position: relative;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      padding-bottom: var(--bottom-band-height);
+    }
+
+    .timeline-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: clamp(32px, 6vw, 48px) clamp(36px, 8vw, 96px) clamp(16px, 4vw, 24px);
+      position: relative;
+      z-index: 1;
+    }
+
+    .brand {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: min(640px, 70vw);
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: clamp(2.1rem, 4vw, 3rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
       color: var(--heading-color);
     }
 
-    .page-subtitle {
+    .brand p {
+      margin: 0;
+      font-size: clamp(1rem, 2vw, 1.3rem);
       color: var(--text-muted);
+      max-width: 42ch;
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
     }
 
     .round-button {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 44px;
-      height: 44px;
-      border-radius: 9999px;
-      background: linear-gradient(135deg, var(--accent-primary), rgba(37, 99, 235, 0.85));
-      color: #ffffff;
-      font-size: 1.35rem;
+      width: 48px;
+      height: 48px;
+      border-radius: 999px;
       border: none;
-      box-shadow: 0 16px 36px -20px rgba(37, 99, 235, 0.55);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    body[data-theme='dark'] .round-button {
-      color: var(--heading-color);
-      background: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(59, 130, 246, 0.75));
-      box-shadow: 0 18px 40px -22px rgba(30, 64, 175, 0.65);
+      cursor: pointer;
+      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+      color: #fff;
+      font-size: 1.35rem;
+      box-shadow: var(--shadow-soft);
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
     }
 
     .round-button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 20px 36px -18px rgba(37, 99, 235, 0.55);
+      transform: translateY(-3px);
+      box-shadow: var(--shadow-strong);
     }
 
-    .round-button:focus-visible {
-      outline: 3px solid rgba(59, 130, 246, 0.45);
-      outline-offset: 3px;
-    }
-
-    .controls-group {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      align-items: stretch;
-      gap: 12px;
-      width: 100%;
-      max-width: 520px;
-    }
-
-    .controls-group__buttons {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 12px;
-      flex-shrink: 0;
-    }
-
-    .century-select {
+    .timeline-overview {
+      padding: 0 clamp(36px, 8vw, 96px) clamp(24px, 6vw, 48px);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: clamp(24px, 6vw, 48px);
       position: relative;
-      display: inline-block;
-      flex: 1 1 220px;
-      min-width: 220px;
-      width: 100%;
-      appearance: none;
-      -webkit-appearance: none;
-      padding: 0.8rem 3.25rem 0.8rem 1.1rem;
-      border-radius: 14px;
-      border: 1px solid rgba(37, 99, 235, 0.35);
-      background: linear-gradient(135deg, rgba(219, 234, 254, 0.96), rgba(191, 219, 254, 0.92));
-      color: #1e293b;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      box-shadow: 0 18px 34px -24px rgba(37, 99, 235, 0.55);
-      transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-      cursor: pointer;
-      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%233256eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-      background-repeat: no-repeat;
-      background-position: right 1.1rem center;
-      background-size: 18px;
-    }
-
-    .century-select option {
-      background-color: rgba(219, 234, 254, 0.96);
-      color: #1e293b;
-    }
-
-    .century-select:disabled {
-      cursor: progress;
-      opacity: 0.7;
-    }
-
-    .century-select:focus,
-    .century-select:focus-visible {
-      border-color: rgba(37, 99, 235, 0.75);
-      box-shadow: 0 18px 34px -20px rgba(37, 99, 235, 0.6), 0 0 0 4px rgba(59, 130, 246, 0.25);
-      outline: none;
-      transform: translateY(-1px);
-    }
-
-    body[data-theme='dark'] .century-select {
-      border-color: rgba(96, 165, 250, 0.45);
-      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.86));
-      color: #e2e8f0;
-      box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.85);
-      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6' stroke='%2396a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-    }
-
-    body[data-theme='dark'] .century-select option {
-      background-color: rgba(15, 23, 42, 0.92);
-      color: #e2e8f0;
-    }
-
-    body[data-theme='dark'] .century-select:focus,
-    body[data-theme='dark'] .century-select:focus-visible {
-      border-color: rgba(147, 197, 253, 0.8);
-      box-shadow: 0 18px 34px -22px rgba(8, 47, 73, 0.85), 0 0 0 4px rgba(96, 165, 250, 0.35);
-    }
-
-    .intro-panel {
-      background: var(--surface);
-      border-radius: 18px;
-      border: 1px solid var(--surface-border);
-      box-shadow: 0 28px 48px -28px rgba(15, 23, 42, 0.55);
-      padding: 28px 32px;
-      margin: 28px auto 0;
-      max-width: 720px;
-      text-align: left;
-    }
-
-    .intro-panel__header {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      gap: 1rem;
-      margin-bottom: 1rem;
-    }
-
-    .intro-panel__close {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-      border-radius: 9999px;
-      background: var(--surface-muted);
-      border: 1px solid var(--surface-border);
-      color: var(--text-primary);
-      font-size: 1.2rem;
-      line-height: 1;
-      cursor: pointer;
-      box-shadow: var(--shadow-soft);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .intro-panel__close:hover,
-    .intro-panel__close:focus-visible {
-      transform: translateY(-1px);
-      outline: none;
-      box-shadow: 0 20px 32px -24px rgba(37, 99, 235, 0.35);
-    }
-
-    body[data-theme='dark'] .intro-panel__close {
-      background: rgba(15, 23, 42, 0.92);
-      color: var(--heading-color);
-    }
-
-    .intro-heading {
-      color: var(--accent-primary-strong);
+      z-index: 1;
     }
 
     .intro-body p {
-      color: var(--text-muted);
-    }
-
-    .intro-grid {
-      display: grid;
-      gap: 16px;
-      margin-top: 24px;
-    }
-
-    @media (min-width: 768px) {
-      .intro-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-
-    .intro-card {
-      background: var(--surface-muted);
+      margin: 0 0 1rem;
+      background: var(--surface);
       border-radius: 16px;
-      border: 1px solid var(--surface-border);
-      padding: 20px 22px;
-      box-shadow: var(--shadow-soft);
-    }
-
-    .intro-card h3 {
-      color: var(--text-primary);
-      margin-bottom: 12px;
-    }
-
-    .intro-card ul {
-      color: var(--text-muted);
-      margin: 0;
-      padding-left: 1.1rem;
-      list-style: disc;
-      display: grid;
-      gap: 0.5rem;
-    }
-
-    .timeline {
-      position: relative;
-      max-width: 980px;
-      margin: 0 auto;
-      padding: 24px 0 64px;
-    }
-
-    .timeline::after {
-      content: '';
-      display: block;
-      height: 55vh;
-      max-height: 520px;
-    }
-
-    .timeline-section {
-      padding-bottom: 20vh;
-    }
-
-    .timeline-century + .timeline-century {
-      margin-top: 48px;
-    }
-
-    .timeline-century__header {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 12px;
-      text-align: center;
-      margin-bottom: 28px;
-    }
-
-    .timeline-century__heading {
-      font-size: 1.75rem;
-      font-weight: 700;
-      color: var(--heading-color);
-      margin: 0;
-    }
-
-    .timeline-century__heading-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      padding: 0.55rem 1.3rem;
-      border-radius: 9999px;
-      border: 1px solid transparent;
-      background: transparent;
-      color: inherit;
-      font: inherit;
-      cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-      box-shadow: none;
-      position: relative;
-    }
-
-    .timeline-century__heading-button::after {
-      content: '';
-      width: 10px;
-      height: 10px;
-      border-right: 2px solid currentColor;
-      border-bottom: 2px solid currentColor;
-      transform: rotate(45deg);
-      transition: transform 0.2s ease;
-    }
-
-    .timeline-century__heading-button[aria-expanded='false']::after {
-      transform: rotate(-45deg);
-    }
-
-    .timeline-century__heading-button:hover,
-    .timeline-century__heading-button:focus-visible {
-      background: var(--surface);
-      border-color: var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      transform: translateY(-1px);
-      outline: none;
-    }
-
-    body[data-theme='dark'] .timeline-century__heading-button {
-      color: var(--heading-color);
-    }
-
-    body[data-theme='dark'] .timeline-century__heading-button:hover,
-    body[data-theme='dark'] .timeline-century__heading-button:focus-visible {
-      background: rgba(15, 23, 42, 0.92);
-      border-color: rgba(96, 165, 250, 0.35);
-    }
-
-    .timeline-century__summary {
-      max-width: 640px;
-      margin: 18px auto 0;
-      color: var(--text-muted);
-      font-style: italic;
-    }
-
-    .timeline-century__entries {
-      position: relative;
-      padding: 56px 0;
-      min-height: calc(var(--century-span, 100) * var(--year-scale));
-      margin-top: 32px;
-      overflow: visible;
-    }
-
-    .timeline-century--collapsed .timeline-century__entries {
-      display: none;
-    }
-
-    .timeline-century__scale {
-      position: absolute;
-      inset: 0;
-      left: 50%;
-      width: var(--axis-column-width);
-      transform: translateX(-50%);
-      pointer-events: none;
-    }
-
-    .timeline-century__scale::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      left: 50%;
-      width: 2px;
-      transform: translateX(-50%);
-      background-image: repeating-linear-gradient(
-        to bottom,
-        rgba(59, 130, 246, 0.4) 0%,
-        rgba(59, 130, 246, 0.4) 2px,
-        transparent 2px,
-        transparent 12px
-      );
-    }
-
-    body[data-theme='dark'] .timeline-century__scale::before {
-      background-image: repeating-linear-gradient(
-        to bottom,
-        rgba(96, 165, 250, 0.55) 0%,
-        rgba(96, 165, 250, 0.55) 2px,
-        transparent 2px,
-        transparent 12px
-      );
-    }
-
-    .timeline-century__ticks {
-      position: absolute;
-      inset: 0;
-    }
-
-    .timeline-century__tick {
-      position: absolute;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 6px;
-      pointer-events: none;
-      z-index: 1;
-    }
-
-    .timeline-century__tick-label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      color: var(--heading-color);
-      background: var(--surface);
-      border: 1px solid var(--surface-border);
-      border-radius: 9999px;
-      padding: 2px 8px;
-      box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.65);
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-label {
-      color: var(--text-primary);
-      background: rgba(15, 23, 42, 0.92);
-      border-color: rgba(96, 165, 250, 0.35);
-      box-shadow: 0 18px 32px -28px rgba(6, 12, 24, 0.85);
-    }
-
-    .timeline-century__tick-mark {
-      position: relative;
-      display: block;
-      width: 6px;
-      height: 6px;
-      border-radius: 9999px;
-      background: rgba(37, 99, 235, 0.75);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-mark {
-      background: rgba(96, 165, 250, 0.8);
-      box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
-    }
-
-    .timeline-century__tick-mark::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      height: 1px;
-      background: rgba(37, 99, 235, 0.4);
-      width: 18px;
-    }
-
-    body[data-theme='dark'] .timeline-century__tick-mark::after {
-      background: rgba(96, 165, 250, 0.45);
-    }
-
-    .timeline-century__tick--year .timeline-century__tick-mark::after {
-      width: 0;
-      height: 0;
-    }
-
-    .timeline-century__tick--quin .timeline-century__tick-mark {
-      width: 7px;
-      height: 7px;
-    }
-
-    .timeline-century__tick--quin .timeline-century__tick-mark::after {
-      width: 26px;
-      opacity: 0.5;
-    }
-
-    .timeline-century__tick--decade .timeline-century__tick-mark {
-      width: 9px;
-      height: 9px;
-    }
-
-    .timeline-century__tick--decade .timeline-century__tick-mark::after {
-      width: 38px;
-      height: 2px;
-      opacity: 0.7;
-    }
-
-    .timeline-century__tick--century .timeline-century__tick-mark {
-      width: 11px;
-      height: 11px;
-    }
-
-    .timeline-century__tick--century .timeline-century__tick-mark::after {
-      width: 52px;
-      height: 3px;
-      opacity: 0.95;
-    }
-
-    .timeline-entry {
-      position: absolute;
-      left: 0;
-      width: 100%;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) var(--axis-column-width) minmax(0, 1fr);
-      column-gap: var(--entry-gap);
-      align-items: center;
-      transform: translateY(calc(-50% + var(--entry-y-offset, 0px)));
-      z-index: 2;
-      --bubble-offset: 0px;
-      --bubble-scale: 1;
-      --connector-length: calc(var(--entry-gap) + var(--axis-column-width) / 2);
-    }
-
-    .timeline-entry__column {
-      display: flex;
-      align-items: center;
-      min-height: var(--bubble-size);
-    }
-
-    .timeline-entry__column--left {
-      justify-content: flex-end;
-    }
-
-    .timeline-entry__column--right {
-      justify-content: flex-start;
-    }
-
-    .timeline-entry__column--empty {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    .timeline-axis {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .timeline-node {
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.75rem 1rem;
-      border-radius: 9999px;
-      background: var(--surface);
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      color: var(--heading-color);
-      font-weight: 700;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-
-    body[data-theme='dark'] .timeline-node {
-      background: rgba(15, 23, 42, 0.92);
-      color: var(--heading-color);
-    }
-
-    .timeline-node::before {
-      content: '';
-      position: absolute;
-      width: 18px;
-      height: 18px;
-      border-radius: 9999px;
-      background: rgba(59, 130, 246, 0.95);
-      box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.18);
-      z-index: -1;
-      opacity: 0.35;
-    }
-
-    body[data-theme='dark'] .timeline-node::before {
-      background: rgba(96, 165, 250, 0.9);
-    }
-
-    .timeline-year {
-      position: relative;
-      z-index: 1;
-    }
-
-    .timeline-bubble {
-      width: var(--bubble-size);
-      height: var(--bubble-size);
-      border-radius: 9999px;
-      border: 2px solid var(--shared-border);
-      background: var(--shared-surface);
-      color: var(--heading-color);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: 700;
-      font-size: 1.15rem;
-      position: relative;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      cursor: pointer;
-      transform: translateX(calc(var(--bubble-shift, 0px))) scale(var(--bubble-scale, 1));
-      transform-origin: center;
-    }
-
-    .timeline-bubble::before {
-      content: attr(data-title);
-      position: absolute;
-      bottom: calc(100% + 10px);
-      left: 50%;
-      transform: translate(-50%, 8px);
-      background: var(--surface);
-      border-radius: 9999px;
-      border: 1px solid var(--surface-border);
-      padding: 0.4rem 0.75rem;
-      white-space: nowrap;
-      font-size: 0.85rem;
-      color: var(--text-primary);
-      box-shadow: var(--shadow-soft);
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.2s ease, transform 0.2s ease;
-    }
-
-    .timeline-bubble:hover::before,
-    .timeline-bubble:focus-visible::before {
-      opacity: 1;
-      transform: translate(-50%, 0);
-    }
-
-    .timeline-bubble:hover,
-    .timeline-bubble:focus-visible {
-      transform: translateX(calc(var(--bubble-shift, 0px))) translateY(-3px) scale(var(--bubble-scale, 1));
-      box-shadow: 0 16px 32px -20px rgba(59, 130, 246, 0.45);
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after,
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      height: 2px;
-      transform: translateY(-50%);
-      pointer-events: none;
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble::after {
-      right: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.75) 0%,
-        rgba(59, 130, 246, 0.68) 74%,
-        rgba(59, 130, 246, 0.92) 100%
-      );
-    }
-
-    .timeline-entry[data-position='right'] .timeline-bubble::after {
-      left: calc(-1 * (var(--connector-length) + 6px));
-      width: calc(var(--connector-length) + 6px);
-      background: linear-gradient(90deg,
-        rgba(59, 130, 246, 0.92) 0%,
-        rgba(59, 130, 246, 0.68) 26%,
-        rgba(59, 130, 246, 0.75) 100%
-      );
-    }
-
-    .timeline-entry[data-position='left'] .timeline-bubble {
-      --bubble-shift: calc(-1 * var(--bubble-offset, 0px));
-    }
-
-    .timeline-entry[data-position='right'] .timeline-bubble {
-      --bubble-shift: var(--bubble-offset, 0px);
-    }
-
-    .timeline-bubble:focus-visible {
-      outline: 3px solid rgba(59, 130, 246, 0.4);
-      outline-offset: 4px;
-    }
-
-    .timeline-bubble--buckler {
-      background: var(--buckler-surface);
-      border-color: var(--buckler-border);
-      color: #065f46;
-    }
-
-    body[data-theme='dark'] .timeline-bubble--buckler {
-      color: var(--text-primary);
-    }
-
-    .timeline-bubble--bp {
-      background: var(--bp-surface);
-      border-color: var(--bp-border);
-      color: #7f1d1d;
-    }
-
-    body[data-theme='dark'] .timeline-bubble--bp {
-      color: var(--text-primary);
-    }
-
-    .timeline-bubble--both {
-      background: var(--shared-surface);
-      border-color: var(--shared-border);
-    }
-
-    .loading-text {
-      color: var(--text-muted);
-      font-size: 1.05rem;
-    }
-
-    .modal {
-      display: none;
-      position: fixed;
-      inset: 0;
-      background: var(--modal-backdrop);
-      z-index: 1000;
-      justify-content: center;
-      align-items: center;
-      padding: 20px;
-    }
-
-    .modal.active {
-      display: flex;
-    }
-
-    .modal-content {
-      background: var(--surface);
-      padding: 28px 30px;
-      border-radius: 18px;
-      max-width: 720px;
-      width: 100%;
-      position: relative;
-      box-shadow: var(--shadow-strong);
-      max-height: 90vh;
-      overflow-y: auto;
-    }
-
-    .modal-content h3 {
-      color: var(--heading-color);
-    }
-
-    .close-btn {
-      position: absolute;
-      top: 14px;
-      right: 16px;
-      font-size: 1.8rem;
-      font-weight: 600;
-      color: var(--text-primary);
-      cursor: pointer;
-      background: none;
-      border: none;
-      line-height: 1;
-    }
-
-    .close-btn:hover,
-    .close-btn:focus-visible {
-      color: var(--accent-primary);
-    }
-
-    .modal-description {
-      color: var(--text-muted);
+      padding: 20px 24px;
       line-height: 1.6;
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
     }
 
-    .modal-summary-text {
-      display: block;
-    }
-
-    .modal-learn-more {
-      align-self: flex-start;
-      padding: 0.55rem 1.2rem;
-      border-radius: 9999px;
-      background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(37, 99, 235, 0.35));
-      border: 1px solid rgba(37, 99, 235, 0.35);
-      color: var(--accent-primary-strong);
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      font-size: 0.75rem;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .modal-learn-more:hover,
-    .modal-learn-more:focus-visible {
-      transform: translateY(-1px);
-      box-shadow: 0 20px 34px -24px rgba(37, 99, 235, 0.45);
-      outline: none;
-    }
-
-    body[data-theme='dark'] .modal-learn-more {
-      background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(96, 165, 250, 0.35));
-      border-color: rgba(96, 165, 250, 0.45);
-      color: var(--accent-primary-strong);
-    }
-
-    .modal-body {
-      margin-top: 20px;
+    .key-themes {
       display: grid;
       gap: 18px;
-      color: var(--text-muted);
     }
 
-    .modal-section-heading {
-      font-size: 0.85rem;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--text-soft);
-      margin-bottom: 8px;
-    }
-
-    .modal-context {
-      list-style: disc;
-      padding-left: 1.2rem;
-      margin: 0;
-      display: grid;
-      gap: 0.35rem;
-    }
-
-    .modal-evidence {
-      display: grid;
-      gap: 14px;
-    }
-
-    .modal-evidence-item {
-      background: var(--surface-muted);
-      border-radius: 14px;
+    .key-theme-card {
+      background: var(--surface);
+      border-radius: 16px;
+      padding: 20px 24px;
       border: 1px solid var(--surface-border);
-      padding: 16px 18px;
+      box-shadow: var(--shadow-soft);
     }
 
-    .modal-evidence-item h5 {
-      font-size: 1rem;
-      font-weight: 600;
+    .key-theme-card h3 {
+      margin: 0 0 0.75rem;
+      font-size: 1.1rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
       color: var(--heading-color);
-      margin-bottom: 6px;
     }
 
-    .modal-evidence-item p {
-      margin: 6px 0 0;
+    .key-theme-card ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.65rem;
       color: var(--text-muted);
     }
 
-    .modal-evidence-meta {
-      font-size: 0.85rem;
-      color: var(--text-soft);
-      margin-top: 8px;
+    .timeline-main {
+      flex: 1;
+      position: relative;
+      z-index: 1;
+      display: flex;
+      align-items: stretch;
+      justify-content: flex-start;
+      padding: clamp(24px, 6vw, 48px);
     }
 
-    .modal-evidence-item iframe,
-    .modal-evidence-item object {
+    .entry-stage {
+      position: relative;
+      flex: 1;
+      display: flex;
+      align-items: flex-end;
+      justify-content: flex-start;
+      padding-bottom: calc(var(--bottom-band-height) + clamp(24px, 4vw, 48px));
+    }
+
+    .entry-panel {
+      position: relative;
+      max-width: min(560px, 70vw);
       width: 100%;
-      min-height: 300px;
-      border: none;
-      border-radius: 12px;
-      margin-top: 12px;
+      background: var(--surface-strong);
+      border-radius: 28px;
+      padding: clamp(24px, 5vw, 40px);
+      border: 1px solid rgba(56, 189, 248, 0.18);
+      box-shadow: 0 40px 120px -60px rgba(15, 23, 42, 0.45);
     }
 
-    @media (max-width: 960px) {
-      :root {
-        --axis-column-width: 120px;
-        --entry-gap: 24px;
+    .entry-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      margin-bottom: clamp(18px, 4vw, 32px);
+    }
+
+    .entry-header h2 {
+      margin: 0;
+      font-size: clamp(1.4rem, 3vw, 2rem);
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--heading-color);
+    }
+
+    .entry-header p {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+
+    .entry-list-viewport {
+      position: relative;
+      overflow: hidden;
+      height: clamp(240px, 42vh, 420px);
+      padding-top: clamp(18px, 3vh, 32px);
+      padding-bottom: clamp(18px, 4vh, 36px);
+    }
+
+    .entry-list {
+      display: flex;
+      flex-direction: column;
+      gap: var(--vertical-gap);
+      transform: translateY(0);
+      transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+    }
+
+    .entry-card {
+      display: block;
+      background: var(--surface);
+      border-radius: 22px;
+      padding: clamp(18px, 3vw, 28px);
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
+      transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+    }
+
+    .entry-card h3 {
+      margin: 0 0 0.55rem;
+      font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+      color: var(--heading-color);
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    .entry-card p {
+      margin: 0;
+      color: var(--text-muted);
+      line-height: 1.55;
+      font-size: 0.98rem;
+    }
+
+    .entry-card.is-active {
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.28), rgba(37, 99, 235, 0.18));
+      border-color: rgba(56, 189, 248, 0.5);
+      transform: translateX(6px);
+    }
+
+    .entry-card:focus-visible {
+      transform: translateX(10px);
+    }
+
+    .year-bar {
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: var(--bottom-band-height);
+      padding: clamp(24px, 4vw, 36px) 0 clamp(18px, 4vw, 32px);
+      display: flex;
+      align-items: flex-end;
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.78) 80%, rgba(15, 23, 42, 0.92) 100%);
+      z-index: 2;
+    }
+
+    body[data-theme='light'] .year-bar {
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0) 0%, rgba(241, 245, 249, 0.85) 78%, rgba(241, 245, 249, 0.96) 100%);
+    }
+
+    .year-bar-viewport {
+      position: relative;
+      flex: 1;
+      overflow: hidden;
+      padding-left: var(--horizontal-padding);
+      padding-right: clamp(36px, 6vw, 84px);
+    }
+
+    .year-bar-fade {
+      position: absolute;
+      right: 0;
+      top: clamp(24px, 4vw, 36px);
+      bottom: clamp(18px, 4vw, 32px);
+      width: 20%;
+      pointer-events: none;
+      background: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.72));
+    }
+
+    body[data-theme='light'] .year-bar-fade {
+      background: linear-gradient(90deg, rgba(241, 245, 249, 0), rgba(241, 245, 249, 0.96));
+    }
+
+    .year-track {
+      display: flex;
+      align-items: center;
+      gap: var(--horizontal-gap);
+      transform: translateX(0);
+      transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+    }
+
+    .year-item {
+      flex: 0 0 auto;
+      min-width: clamp(140px, 18vw, 220px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--surface);
+      border-radius: 22px;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
+      padding: clamp(16px, 3vw, 24px);
+      font-size: clamp(1.05rem, 2.6vw, 1.5rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      color: var(--heading-color);
+      transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
+        box-shadow 0.35s ease, border-color 0.35s ease;
+    }
+
+    .year-item.is-active {
+      transform: scale(1.08) translateY(-6px);
+      box-shadow: var(--shadow-strong);
+      border-color: rgba(56, 189, 248, 0.5);
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(37, 99, 235, 0.18));
+    }
+
+    .loading-banner {
+      position: fixed;
+      top: 18px;
+      right: 18px;
+      padding: 0.65rem 1rem;
+      background: var(--surface-strong);
+      border-radius: 999px;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
+      font-size: 0.95rem;
+      color: var(--text-muted);
+      z-index: 3;
+    }
+
+    .loading-banner.hidden {
+      display: none;
+    }
+
+    @media (max-width: 1024px) {
+      .timeline-overview {
+        grid-template-columns: 1fr;
       }
 
-      .timeline-century__heading {
-        font-size: 1.5rem;
+      .entry-panel {
+        max-width: min(600px, 100%);
       }
     }
 
     @media (max-width: 760px) {
       :root {
-        --axis-column-width: 100px;
-        --entry-gap: 18px;
-        --bubble-size: 54px;
+        --bottom-band-height: clamp(220px, 40vh, 320px);
       }
 
-      .timeline {
-        padding-left: 12px;
-        padding-right: 12px;
+      .timeline-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 18px;
       }
 
-      .timeline::before {
-        left: 22px;
+      .header-actions {
+        align-self: flex-end;
       }
 
-      .timeline-entry {
-        grid-template-columns: var(--axis-column-width) 1fr;
-        column-gap: 16px;
+      .timeline-overview {
+        padding-left: clamp(18px, 6vw, 32px);
+        padding-right: clamp(18px, 6vw, 32px);
       }
 
-      .timeline-entry__column--left,
-      .timeline-entry__column--right {
-        grid-column: 2 / span 1;
-        justify-content: flex-start;
+      .timeline-main {
+        padding: clamp(18px, 6vw, 32px);
       }
 
-      .timeline-entry[data-position='left'] .timeline-bubble::after,
-      .timeline-entry[data-position='right'] .timeline-bubble::after {
-        left: calc(-1 * (var(--axis-column-width) - 16px));
-        right: auto;
-        width: calc(var(--axis-column-width) - 12px);
-        background: linear-gradient(90deg, rgba(59, 130, 246, 0.65), rgba(59, 130, 246, 0));
+      .entry-stage {
+        padding-bottom: calc(var(--bottom-band-height) + clamp(24px, 6vw, 40px));
       }
 
-      .timeline-entry__column--left.timeline-entry__column--empty,
-      .timeline-entry__column--right.timeline-entry__column--empty {
-        display: none;
+      .entry-panel {
+        border-radius: 24px;
+      }
+
+      .year-item {
+        min-width: clamp(120px, 42vw, 180px);
       }
     }
 
     @media (max-width: 540px) {
-      .round-button {
-        width: 40px;
-        height: 40px;
-        font-size: 1.2rem;
+      .entry-panel {
+        padding: clamp(18px, 6vw, 28px);
       }
 
-      .timeline-bubble::before {
-        font-size: 0.8rem;
-      }
-
-      .modal-content {
-        padding: 24px 22px;
+      .entry-list-viewport {
+        height: clamp(220px, 48vh, 360px);
       }
     }
   </style>
 </head>
-<body class="font-sans" data-theme="light">
-  <div class="container mx-auto px-4 py-10">
-    <header class="text-center">
-      <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Occupied for centuries by the Williams/ Buckler family.</p>
+<body data-theme="light">
+  <div class="timeline-app">
+    <header class="timeline-header">
+      <div class="brand">
+        <h1 id="case-title">Great House Farm</h1>
+        <p id="case-subtitle"></p>
       </div>
-      <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
-        <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
-        <div class="controls-group">
-          <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
-              <span class="sr-only">Toggle colour theme</span>
-              <span aria-hidden="true" data-theme-icon>☀️</span>
-            </button>
-            <button id="intro-toggle" class="round-button" type="button" aria-expanded="false" aria-controls="intro-panel" title="About this timeline">
-              <span aria-hidden="true">ℹ️</span>
-              <span class="sr-only">Toggle introduction</span>
-            </button>
-          </div>
-          <select id="century-select" class="century-select" disabled>
-            <option value="">Loading centuries…</option>
-          </select>
-        </div>
-      </div>
-      <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
-        <div class="intro-panel__header">
-          <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
-        </div>
-        <div id="case-intro" class="intro-body space-y-4"></div>
-        <div id="key-themes" class="intro-grid"></div>
+      <div class="header-actions">
+        <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+          <span class="sr-only">Toggle colour theme</span>
+          <span aria-hidden="true" data-theme-icon>☀️</span>
+        </button>
       </div>
     </header>
 
-    <section class="mt-14 timeline-section">
-      <div id="timeline-loading" class="text-center loading-text">Loading timeline data…</div>
-      <div class="timeline" id="timeline" aria-live="polite"></div>
+    <section class="timeline-overview">
+      <div id="case-intro" class="intro-body"></div>
+      <div id="key-themes" class="key-themes"></div>
     </section>
+
+    <main class="timeline-main">
+      <div class="entry-stage">
+        <div class="entry-panel">
+          <header class="entry-header">
+            <p id="timeline-year-meta"></p>
+            <h2 id="timeline-year-title"></h2>
+          </header>
+          <div class="entry-list-viewport" id="timeline-entry-viewport">
+            <div class="entry-list" id="timeline-year-entries"></div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <nav class="year-bar" aria-label="Timeline years">
+      <div class="year-bar-viewport" id="year-bar-viewport">
+        <div class="year-track" id="timeline-year-track" role="listbox" aria-label="Timeline years"></div>
+      </div>
+      <div class="year-bar-fade" aria-hidden="true"></div>
+    </nav>
+
+    <div id="timeline-loading" class="loading-banner">Loading timeline…</div>
   </div>
 
-  <div id="modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-    <div class="modal-content">
-      <button class="close-btn" type="button" aria-label="Close event details">&times;</button>
-      <h3 id="modal-title" class="text-2xl font-semibold"></h3>
-      <p id="modal-source" class="text-sm mt-2 text-slate-500 dark:text-slate-300"></p>
-      <p id="modal-description" class="text-base modal-description mt-4"></p>
-      <div id="modal-body" class="modal-body"></div>
-    </div>
-  </div>
-
-    <script src="timeline.js"></script>
-
+  <script src="timeline.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -7,64 +7,34 @@
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
-      color-scheme: light;
-      --page-background: #0f172a;
-      --surface: rgba(15, 23, 42, 0.7);
-      --surface-strong: rgba(15, 23, 42, 0.9);
-      --surface-muted: rgba(15, 23, 42, 0.6);
-      --surface-border: rgba(148, 163, 184, 0.2);
-      --heading-color: #f8fafc;
-      --text-primary: #e2e8f0;
-      --text-muted: rgba(226, 232, 240, 0.75);
-      --accent: #38bdf8;
-      --accent-soft: rgba(56, 189, 248, 0.2);
-      --accent-strong: #0ea5e9;
-      --shadow-soft: 0 30px 80px -40px rgba(15, 23, 42, 0.8);
-      --shadow-strong: 0 40px 120px -60px rgba(14, 165, 233, 0.4);
-      --bottom-band-height: clamp(240px, 33vh, 360px);
-      --horizontal-gap: clamp(18px, 4vw, 36px);
-      --horizontal-padding: clamp(54px, 6vw, 112px);
-      --vertical-gap: clamp(16px, 2.8vh, 28px);
-    }
-
-    body[data-theme='light'] {
-      color-scheme: light;
-      --page-background: #f1f5f9;
-      --surface: rgba(255, 255, 255, 0.72);
-      --surface-strong: rgba(255, 255, 255, 0.92);
-      --surface-muted: rgba(255, 255, 255, 0.6);
-      --surface-border: rgba(148, 163, 184, 0.18);
-      --heading-color: #0f172a;
-      --text-primary: #1e293b;
-      --text-muted: rgba(30, 41, 59, 0.7);
-      --accent: #2563eb;
-      --accent-soft: rgba(37, 99, 235, 0.12);
-      --accent-strong: #1d4ed8;
-      --shadow-soft: 0 30px 80px -48px rgba(15, 23, 42, 0.25);
-      --shadow-strong: 0 40px 120px -60px rgba(37, 99, 235, 0.35);
-    }
-
-    body[data-theme='dark'] {
       color-scheme: dark;
+      --page-background: #04070c;
+      --surface: rgba(12, 18, 32, 0.82);
+      --surface-strong: rgba(20, 30, 48, 0.94);
+      --surface-border: rgba(148, 163, 184, 0.18);
+      --text-primary: #e2e8f0;
+      --text-muted: rgba(148, 163, 184, 0.75);
+      --accent: #38bdf8;
+      --horizontal-band-height: clamp(220px, 34vh, 320px);
+      --horizontal-padding: clamp(40px, 8vw, 128px);
+      --horizontal-gap: clamp(36px, 8vw, 72px);
+      --horizontal-icon: clamp(48px, 10vw, 96px);
+      --vertical-gap: clamp(18px, 4vh, 32px);
+      --vertical-icon: clamp(40px, 7vw, 68px);
+      --fade-width: 20%;
     }
 
     *, *::before, *::after {
       box-sizing: border-box;
     }
 
-    .hidden {
-      display: none !important;
-    }
-
-    body {
+    html, body {
       margin: 0;
-      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 42%),
-        radial-gradient(circle at top right, rgba(14, 165, 233, 0.24), transparent 48%),
-        var(--page-background);
+      height: 100%;
+      background: var(--page-background);
       color: var(--text-primary);
-      min-height: 100vh;
-      overflow-x: hidden;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      overflow: hidden;
     }
 
     a {
@@ -72,189 +42,45 @@
       text-decoration: none;
     }
 
-    a:focus-visible,
-    button:focus-visible {
-      outline: 3px solid var(--accent);
-      outline-offset: 4px;
+    .is-hidden {
+      display: none !important;
     }
 
-    .timeline-app {
+    .xmb-shell {
       position: relative;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
-      padding-bottom: var(--bottom-band-height);
+      background: var(--page-background);
+      isolation: isolate;
     }
 
-    .timeline-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: clamp(32px, 6vw, 48px) clamp(36px, 8vw, 96px) clamp(16px, 4vw, 24px);
-      position: relative;
-      z-index: 1;
-    }
-
-    .brand {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      max-width: min(640px, 70vw);
-    }
-
-    .brand h1 {
-      margin: 0;
-      font-size: clamp(2.1rem, 4vw, 3rem);
-      font-weight: 800;
-      letter-spacing: -0.02em;
-      color: var(--heading-color);
-    }
-
-    .brand p {
-      margin: 0;
-      font-size: clamp(1rem, 2vw, 1.3rem);
-      color: var(--text-muted);
-      max-width: 42ch;
-    }
-
-    .header-actions {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-
-    .round-button {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 48px;
-      height: 48px;
-      border-radius: 999px;
-      border: none;
-      cursor: pointer;
-      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-      color: #fff;
-      font-size: 1.35rem;
-      box-shadow: var(--shadow-soft);
-      transition: transform 0.25s ease, box-shadow 0.25s ease;
-    }
-
-    .round-button:hover {
-      transform: translateY(-3px);
-      box-shadow: var(--shadow-strong);
-    }
-
-    .timeline-overview {
-      padding: 0 clamp(36px, 8vw, 96px) clamp(24px, 6vw, 48px);
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: clamp(24px, 6vw, 48px);
-      position: relative;
-      z-index: 1;
-    }
-
-    .intro-body p {
-      margin: 0 0 1rem;
-      background: var(--surface);
-      border-radius: 16px;
-      padding: 20px 24px;
-      line-height: 1.6;
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-    }
-
-    .key-themes {
-      display: grid;
-      gap: 18px;
-    }
-
-    .key-theme-card {
-      background: var(--surface);
-      border-radius: 16px;
-      padding: 20px 24px;
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-    }
-
-    .key-theme-card h3 {
-      margin: 0 0 0.75rem;
-      font-size: 1.1rem;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      color: var(--heading-color);
-    }
-
-    .key-theme-card ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.65rem;
-      color: var(--text-muted);
-    }
-
-    .timeline-main {
-      flex: 1;
-      position: relative;
-      z-index: 1;
-      display: flex;
-      align-items: stretch;
-      justify-content: flex-start;
-      padding: clamp(24px, 6vw, 48px);
-    }
-
-    .entry-stage {
+    .xmb-stage {
       position: relative;
       flex: 1;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    .xmb-vertical {
+      position: absolute;
+      left: var(--horizontal-padding);
+      right: calc(var(--horizontal-padding) + var(--horizontal-gap));
+      bottom: calc(var(--horizontal-band-height) + clamp(18px, 4vh, 36px));
       display: flex;
       align-items: flex-end;
       justify-content: flex-start;
-      padding-bottom: calc(var(--bottom-band-height) + clamp(24px, 4vw, 48px));
+      z-index: 1;
     }
 
-    .entry-panel {
-      position: relative;
-      max-width: min(560px, 70vw);
-      width: 100%;
-      background: var(--surface-strong);
-      border-radius: 28px;
-      padding: clamp(24px, 5vw, 40px);
-      border: 1px solid rgba(56, 189, 248, 0.18);
-      box-shadow: 0 40px 120px -60px rgba(15, 23, 42, 0.45);
-    }
-
-    .entry-header {
-      display: flex;
-      flex-direction: column;
-      gap: 0.35rem;
-      margin-bottom: clamp(18px, 4vw, 32px);
-    }
-
-    .entry-header h2 {
-      margin: 0;
-      font-size: clamp(1.4rem, 3vw, 2rem);
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      color: var(--heading-color);
-    }
-
-    .entry-header p {
-      margin: 0;
-      color: var(--text-muted);
-      font-size: 0.95rem;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-    }
-
-    .entry-list-viewport {
-      position: relative;
+    .xmb-vertical__viewport {
+      width: min(480px, 46vw);
+      max-width: 520px;
+      height: clamp(200px, 32vh, 300px);
       overflow: hidden;
-      height: clamp(240px, 42vh, 420px);
-      padding-top: clamp(18px, 3vh, 32px);
-      padding-bottom: clamp(18px, 4vh, 36px);
     }
 
-    .entry-list {
+    .xmb-vertical__list {
       display: flex;
       flex-direction: column;
       gap: var(--vertical-gap);
@@ -262,234 +88,250 @@
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
     }
 
-    .entry-card {
-      display: block;
+    .xmb-entry {
+      display: flex;
+      align-items: center;
+      gap: clamp(14px, 3vw, 28px);
+      padding: clamp(16px, 3vw, 28px) clamp(20px, 4vw, 32px);
       background: var(--surface);
-      border-radius: 22px;
-      padding: clamp(18px, 3vw, 28px);
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+      border-radius: clamp(22px, 6vw, 32px);
+      border: 1px solid transparent;
+      color: var(--text-primary);
+      filter: drop-shadow(0 24px 45px rgba(2, 6, 23, 0.55));
+      opacity: 0.65;
+      transform: scale(0.96);
+      transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
+        opacity 0.35s ease,
+        border-color 0.35s ease,
+        background 0.35s ease;
+      pointer-events: auto;
     }
 
-    .entry-card h3 {
-      margin: 0 0 0.55rem;
-      font-size: clamp(1.05rem, 2.4vw, 1.35rem);
-      color: var(--heading-color);
+    .xmb-entry__icon {
+      font-size: var(--vertical-icon);
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1em;
+    }
+
+    .xmb-entry__copy {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(4px, 1vh, 8px);
+      text-transform: none;
+      font-size: clamp(0.85rem, 2vw, 1rem);
+    }
+
+    .xmb-entry__title {
       font-weight: 700;
-      letter-spacing: -0.01em;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-primary);
+      font-size: clamp(0.9rem, 2.2vw, 1.05rem);
     }
 
-    .entry-card p {
-      margin: 0;
+    .xmb-entry__subtitle {
       color: var(--text-muted);
-      line-height: 1.55;
-      font-size: 0.98rem;
+      font-size: clamp(0.75rem, 1.8vw, 0.9rem);
+      letter-spacing: 0.04em;
     }
 
-    .entry-card.is-active {
-      background: linear-gradient(135deg, rgba(56, 189, 248, 0.28), rgba(37, 99, 235, 0.18));
-      border-color: rgba(56, 189, 248, 0.5);
-      transform: translateX(6px);
+    .xmb-entry.is-active {
+      opacity: 1;
+      background: var(--surface-strong);
+      border-color: rgba(56, 189, 248, 0.35);
+      transform: scale(1.02);
     }
 
-    .entry-card:focus-visible {
-      transform: translateX(10px);
+    .xmb-entry:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 4px;
     }
 
-    .year-bar {
-      position: fixed;
+    .xmb-horizontal {
+      position: absolute;
       left: 0;
       right: 0;
       bottom: 0;
-      height: var(--bottom-band-height);
-      padding: clamp(24px, 4vw, 36px) 0 clamp(18px, 4vw, 32px);
+      height: var(--horizontal-band-height);
       display: flex;
       align-items: flex-end;
-      background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.78) 80%, rgba(15, 23, 42, 0.92) 100%);
+      padding-bottom: clamp(32px, 6vh, 52px);
+      background: transparent;
       z-index: 2;
     }
 
-    body[data-theme='light'] .year-bar {
-      background: linear-gradient(180deg, rgba(241, 245, 249, 0) 0%, rgba(241, 245, 249, 0.85) 78%, rgba(241, 245, 249, 0.96) 100%);
-    }
-
-    .year-bar-viewport {
-      position: relative;
+    .xmb-horizontal__viewport {
       flex: 1;
       overflow: hidden;
       padding-left: var(--horizontal-padding);
-      padding-right: clamp(36px, 6vw, 84px);
+      padding-right: clamp(32px, 6vw, 64px);
+      position: relative;
     }
 
-    .year-bar-fade {
-      position: absolute;
-      right: 0;
-      top: clamp(24px, 4vw, 36px);
-      bottom: clamp(18px, 4vw, 32px);
-      width: 20%;
-      pointer-events: none;
-      background: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.72));
-    }
-
-    body[data-theme='light'] .year-bar-fade {
-      background: linear-gradient(90deg, rgba(241, 245, 249, 0), rgba(241, 245, 249, 0.96));
-    }
-
-    .year-track {
+    .xmb-horizontal__track {
       display: flex;
       align-items: center;
       gap: var(--horizontal-gap);
       transform: translateX(0);
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+      will-change: transform;
     }
 
-    .year-item {
-      flex: 0 0 auto;
-      min-width: clamp(140px, 18vw, 220px);
+    .xmb-year {
       display: flex;
       align-items: center;
-      justify-content: center;
+      gap: clamp(16px, 3vw, 32px);
+      padding: clamp(18px, 4vw, 32px) clamp(24px, 6vw, 40px);
+      border-radius: clamp(26px, 7vw, 40px);
       background: var(--surface);
-      border-radius: 22px;
       border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      padding: clamp(16px, 3vw, 24px);
-      font-size: clamp(1.05rem, 2.6vw, 1.5rem);
+      color: var(--text-primary);
+      cursor: pointer;
+      filter: drop-shadow(0 26px 48px rgba(2, 6, 23, 0.52));
+      transform: translateY(0) scale(1);
+      transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1),
+        border-color 0.35s ease,
+        background 0.35s ease,
+        color 0.35s ease;
+      min-width: clamp(200px, 28vw, 280px);
+    }
+
+    .xmb-year__icon {
+      font-size: var(--horizontal-icon);
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1em;
+    }
+
+    .xmb-year__copy {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(4px, 1vh, 10px);
+      text-align: left;
+    }
+
+    .xmb-year__title {
       font-weight: 700;
+      font-size: clamp(1rem, 2.6vw, 1.35rem);
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      cursor: pointer;
-      color: var(--heading-color);
-      transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
-        box-shadow 0.35s ease, border-color 0.35s ease;
+      color: var(--text-primary);
     }
 
-    .year-item.is-active {
-      transform: scale(1.08) translateY(-6px);
-      box-shadow: var(--shadow-strong);
-      border-color: rgba(56, 189, 248, 0.5);
-      background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(37, 99, 235, 0.18));
-    }
-
-    .loading-banner {
-      position: fixed;
-      top: 18px;
-      right: 18px;
-      padding: 0.65rem 1rem;
-      background: var(--surface-strong);
-      border-radius: 999px;
-      border: 1px solid var(--surface-border);
-      box-shadow: var(--shadow-soft);
-      font-size: 0.95rem;
+    .xmb-year__subtitle {
+      font-size: clamp(0.8rem, 2vw, 0.95rem);
+      letter-spacing: 0.05em;
       color: var(--text-muted);
+    }
+
+    .xmb-year.is-active {
+      transform: translateY(-12px) scale(1.12);
+      background: var(--surface-strong);
+      border-color: rgba(56, 189, 248, 0.4);
+      color: #f8fafc;
+    }
+
+    .xmb-year:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 5px;
+    }
+
+    .xmb-horizontal__fade {
+      position: absolute;
+      top: clamp(12px, 3vh, 24px);
+      bottom: clamp(12px, 3vh, 24px);
+      right: 0;
+      width: var(--fade-width);
+      background: linear-gradient(90deg, rgba(4, 7, 12, 0) 0%, rgba(4, 7, 12, 0.95) 90%);
+      pointer-events: none;
       z-index: 3;
     }
 
-    .loading-banner.hidden {
+    .xmb-loading {
+      position: fixed;
+      top: 18px;
+      right: 18px;
+      padding: 0.65rem 1.2rem;
+      background: var(--surface-strong);
+      border-radius: 999px;
+      border: 1px solid var(--surface-border);
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      box-shadow: 0 18px 48px rgba(2, 6, 23, 0.45);
+      z-index: 4;
+    }
+
+    .xmb-loading.is-hidden {
       display: none;
     }
 
-    @media (max-width: 1024px) {
-      .timeline-overview {
-        grid-template-columns: 1fr;
-      }
-
-      .entry-panel {
-        max-width: min(600px, 100%);
-      }
-    }
-
-    @media (max-width: 760px) {
+    @media (max-width: 900px) {
       :root {
-        --bottom-band-height: clamp(220px, 40vh, 320px);
+        --horizontal-band-height: clamp(220px, 42vh, 320px);
+        --horizontal-padding: clamp(28px, 8vw, 72px);
+        --horizontal-gap: clamp(28px, 10vw, 48px);
+        --horizontal-icon: clamp(48px, 14vw, 72px);
+        --vertical-gap: clamp(14px, 4vh, 24px);
+        --vertical-icon: clamp(36px, 10vw, 58px);
       }
 
-      .timeline-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 18px;
+      .xmb-vertical__viewport {
+        width: min(420px, 80vw);
       }
 
-      .header-actions {
-        align-self: flex-end;
-      }
-
-      .timeline-overview {
-        padding-left: clamp(18px, 6vw, 32px);
-        padding-right: clamp(18px, 6vw, 32px);
-      }
-
-      .timeline-main {
-        padding: clamp(18px, 6vw, 32px);
-      }
-
-      .entry-stage {
-        padding-bottom: calc(var(--bottom-band-height) + clamp(24px, 6vw, 40px));
-      }
-
-      .entry-panel {
-        border-radius: 24px;
-      }
-
-      .year-item {
-        min-width: clamp(120px, 42vw, 180px);
+      .xmb-year {
+        min-width: clamp(160px, 44vw, 220px);
       }
     }
 
-    @media (max-width: 540px) {
-      .entry-panel {
-        padding: clamp(18px, 6vw, 28px);
+    @media (max-width: 640px) {
+      html, body {
+        overflow: hidden;
       }
 
-      .entry-list-viewport {
-        height: clamp(220px, 48vh, 360px);
+      .xmb-horizontal {
+        padding-bottom: clamp(24px, 8vh, 40px);
+      }
+
+      .xmb-vertical {
+        left: clamp(20px, 8vw, 32px);
+        right: clamp(20px, 12vw, 40px);
+      }
+
+      .xmb-vertical__viewport {
+        width: 100%;
+        height: clamp(220px, 44vh, 320px);
+      }
+
+      .xmb-year__title {
+        font-size: clamp(0.95rem, 4vw, 1.2rem);
       }
     }
   </style>
 </head>
-<body data-theme="light">
-  <div class="timeline-app">
-    <header class="timeline-header">
-      <div class="brand">
-        <h1 id="case-title">Great House Farm</h1>
-        <p id="case-subtitle"></p>
-      </div>
-      <div class="header-actions">
-        <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
-          <span class="sr-only">Toggle colour theme</span>
-          <span aria-hidden="true" data-theme-icon>☀️</span>
-        </button>
-      </div>
-    </header>
-
-    <section class="timeline-overview">
-      <div id="case-intro" class="intro-body"></div>
-      <div id="key-themes" class="key-themes"></div>
-    </section>
-
-    <main class="timeline-main">
-      <div class="entry-stage">
-        <div class="entry-panel">
-          <header class="entry-header">
-            <p id="timeline-year-meta"></p>
-            <h2 id="timeline-year-title"></h2>
-          </header>
-          <div class="entry-list-viewport" id="timeline-entry-viewport">
-            <div class="entry-list" id="timeline-year-entries"></div>
-          </div>
+<body>
+  <div class="xmb-shell">
+    <main class="xmb-stage">
+      <section class="xmb-vertical" aria-label="Timeline entries">
+        <div class="xmb-vertical__viewport" id="timeline-entry-viewport">
+          <div class="xmb-vertical__list" id="timeline-year-entries"></div>
         </div>
-      </div>
+      </section>
     </main>
 
-    <nav class="year-bar" aria-label="Timeline years">
-      <div class="year-bar-viewport" id="year-bar-viewport">
-        <div class="year-track" id="timeline-year-track" role="listbox" aria-label="Timeline years"></div>
+    <nav class="xmb-horizontal" aria-label="Timeline years">
+      <div class="xmb-horizontal__viewport" id="year-bar-viewport">
+        <div class="xmb-horizontal__track" id="timeline-year-track" role="listbox" aria-label="Timeline years"></div>
+        <div class="xmb-horizontal__fade" aria-hidden="true"></div>
       </div>
-      <div class="year-bar-fade" aria-hidden="true"></div>
     </nav>
 
-    <div id="timeline-loading" class="loading-banner">Loading timeline…</div>
+    <div id="timeline-loading" class="xmb-loading">Loading timeline…</div>
   </div>
 
   <script src="timeline.js"></script>

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -2,29 +2,26 @@
   const body = document.body;
   const themeToggle = document.getElementById('theme-toggle');
   const themeIcon = themeToggle ? themeToggle.querySelector('[data-theme-icon]') : null;
-  const introToggle = document.getElementById('intro-toggle');
-  const introPanel = document.getElementById('intro-panel');
-  const introClose = document.getElementById('intro-close');
   const caseTitle = document.getElementById('case-title');
   const caseSubtitle = document.getElementById('case-subtitle');
   const caseIntro = document.getElementById('case-intro');
   const keyThemes = document.getElementById('key-themes');
-  const centurySelector = document.getElementById('century-selector');
-  const centurySelect = document.getElementById('century-select');
-  const timelineContainer = document.getElementById('timeline');
-  const loadingMessage = document.getElementById('timeline-loading');
-  const modal = document.getElementById('modal');
-  const closeBtn = modal ? modal.querySelector('.close-btn') : null;
-  const modalTitle = document.getElementById('modal-title');
-  const modalSource = document.getElementById('modal-source');
-  const modalDescription = document.getElementById('modal-description');
-  const modalBody = document.getElementById('modal-body');
+  const yearTrack = document.getElementById('timeline-year-track');
+  const yearViewport = document.getElementById('year-bar-viewport');
+  const loadingBanner = document.getElementById('timeline-loading');
+  const yearTitle = document.getElementById('timeline-year-title');
+  const yearMeta = document.getElementById('timeline-year-meta');
+  const entryViewport = document.getElementById('timeline-entry-viewport');
+  const entryList = document.getElementById('timeline-year-entries');
 
-  const eventIndex = new Map();
   const storageKey = 'ghf-theme';
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-  let sharedSidePreference = 'right';
-  let centuriesData = [];
+
+  let yearGroups = [];
+  let yearButtons = [];
+  let entryLinks = [];
+  let activeYearIndex = 0;
+  let activeEntryIndex = 0;
 
   function setTheme(theme, persist = true) {
     const normalized = theme === 'dark' ? 'dark' : 'light';
@@ -40,7 +37,7 @@
       try {
         localStorage.setItem(storageKey, normalized);
       } catch (error) {
-        console.warn('Unable to persist theme preference', error);
+        // ignore persistence errors
       }
     }
   }
@@ -76,842 +73,424 @@
     }
   });
 
-  function choosePosition(event) {
-    if (event.side === 'buckler') {
-      return 'left';
-    }
-    if (event.side === 'bp') {
-      return 'right';
-    }
-    sharedSidePreference = sharedSidePreference === 'left' ? 'right' : 'left';
-    return sharedSidePreference;
-  }
-
-  function normalizeCenturyBounds(century) {
-    const start = Number(century?.startYear);
-    const end = Number(century?.endYear);
-    if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
-      return { startYear: start, endYear: end, span: Math.max(1, end - start) };
-    }
-    if (Number.isFinite(start)) {
-      const inferredEnd = start + 99;
-      return { startYear: start, endYear: inferredEnd, span: Math.max(1, inferredEnd - start) };
-    }
-    if (Number.isFinite(end)) {
-      const inferredStart = end - 99;
-      return { startYear: inferredStart, endYear: end, span: Math.max(1, end - inferredStart) };
-    }
-    return { startYear: 0, endYear: 99, span: 99 };
-  }
-
-  function getEventYearValue(event, bounds) {
-    if (!event) {
-      return bounds.endYear;
-    }
-    const direct = Number(event.yearValue);
+  function getEventYearValue(event) {
+    const direct = Number(event?.yearValue);
     if (Number.isFinite(direct)) {
       return direct;
     }
-    const match = typeof event.year === 'string' ? event.year.match(/(1[6-9]\d{2}|20\d{2})/) : null;
+    const match = typeof event?.year === 'string' ? event.year.match(/(1[0-9]{3}|20[0-9]{2})/) : null;
     if (match) {
       return Number(match[0]);
     }
-    return bounds.endYear;
+    return null;
   }
 
-  function positionForYear(year, bounds) {
-    const { startYear, endYear, span } = bounds;
-    if (!Number.isFinite(year)) {
-      return 0;
-    }
-    const clamped = Math.min(Math.max(year, startYear), endYear);
-    const offset = clamped - startYear;
-    const raw = (offset / span) * 100;
-    return Math.min(98, Math.max(2, raw));
+  function sanitizeKey(value, fallback) {
+    const base = String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return base || fallback;
   }
 
-  function buildCenturyScale(container, bounds) {
-    if (!container) {
-      return;
-    }
-    const scale = document.createElement('div');
-    scale.className = 'timeline-century__scale';
+  function buildYearGroups(data) {
+    const groups = new Map();
 
-    const ticks = document.createElement('div');
-    ticks.className = 'timeline-century__ticks';
-    scale.appendChild(ticks);
-
-    const { startYear, endYear, span } = bounds;
-    for (let year = startYear; year <= endYear; year += 1) {
-      const tick = document.createElement('div');
-      tick.className = 'timeline-century__tick timeline-century__tick--year';
-      if (year % 5 === 0) {
-        tick.classList.add('timeline-century__tick--quin');
-      }
-      if (year % 10 === 0) {
-        tick.classList.add('timeline-century__tick--decade');
-      }
-      if (year % 100 === 0) {
-        tick.classList.add('timeline-century__tick--century');
-      }
-
-      const offset = ((year - startYear) / span) * 100;
-      const position = Math.min(100, Math.max(0, offset));
-      tick.style.top = `${position}%`;
-
-      if (year % 10 === 0) {
-        const label = document.createElement('span');
-        label.className = 'timeline-century__tick-label';
-        label.textContent = String(year);
-        tick.appendChild(label);
-      }
-
-      const mark = document.createElement('span');
-      mark.className = 'timeline-century__tick-mark';
-      tick.appendChild(mark);
-
-      ticks.appendChild(tick);
-    }
-
-    container.prepend(scale);
-  }
-
-  function buildEvent(event, century, bounds) {
-    const position = choosePosition(event);
-    const entry = document.createElement('div');
-    entry.className = 'timeline-entry';
-    entry.dataset.position = position;
-    entry.dataset.eventId = event.id;
-
-    const eventYear = getEventYearValue(event, bounds);
-    const topPosition = positionForYear(eventYear, bounds);
-    entry.style.top = `${topPosition}%`;
-    entry.dataset.yearPosition = topPosition.toFixed(3);
-    if (Number.isFinite(eventYear)) {
-      entry.dataset.yearValue = String(eventYear);
-    }
-
-    const leftColumn = document.createElement('div');
-    leftColumn.className = 'timeline-entry__column timeline-entry__column--left';
-
-    const axisColumn = document.createElement('div');
-    axisColumn.className = 'timeline-axis';
-    axisColumn.setAttribute('aria-hidden', 'true');
-
-    const yearWrapper = document.createElement('div');
-    yearWrapper.className = 'timeline-year';
-    const node = document.createElement('div');
-    node.className = 'timeline-node';
-    const yearLabel = (event.year && String(event.year).trim()) || (Number.isFinite(eventYear) ? String(eventYear) : '');
-    node.textContent = yearLabel || '•';
-    yearWrapper.appendChild(node);
-    axisColumn.appendChild(yearWrapper);
-
-    const rightColumn = document.createElement('div');
-    rightColumn.className = 'timeline-entry__column timeline-entry__column--right';
-
-    const bubble = document.createElement('button');
-    bubble.className = `timeline-bubble timeline-bubble--${event.side || 'both'}`;
-    bubble.type = 'button';
-    bubble.dataset.eventId = event.id;
-    bubble.dataset.title = event.title;
-
-    const bubbleYear = (() => {
-      if (Number.isFinite(eventYear)) {
-        return Math.round(eventYear);
-      }
-      const match = typeof event.year === 'string' ? event.year.match(/(1[5-9]\d{2}|20\d{2})/) : null;
-      if (match) {
-        return Number(match[0]);
-      }
-      const fallbackMatch = typeof event.label === 'string' ? event.label.match(/(1[5-9]\d{2}|20\d{2})/) : null;
-      return fallbackMatch ? Number(fallbackMatch[0]) : null;
-    })();
-
-    const bubbleIcon = typeof event.icon === 'string' && event.icon.trim().length ? event.icon.trim() : null;
-    const bubbleLabel = bubbleIcon || (bubbleYear != null ? String(bubbleYear).padStart(4, '0') : (event.year ? String(event.year) : (event.label || '•')));
-    const bubbleIconLabel = typeof event.iconLabel === 'string' && event.iconLabel.trim().length ? event.iconLabel.trim() : null;
-
-    const accessibilityLabelParts = [event.title];
-    if (bubbleIconLabel) {
-      accessibilityLabelParts.push(bubbleIconLabel);
-    }
-    if (bubbleYear != null) {
-      accessibilityLabelParts.push(String(bubbleYear));
-    } else if (event.year) {
-      accessibilityLabelParts.push(String(event.year));
-    }
-
-    const accessibilityLabel = accessibilityLabelParts.join(' – ');
-
-    bubble.setAttribute('aria-label', accessibilityLabel);
-    bubble.setAttribute('title', accessibilityLabel);
-    bubble.textContent = bubbleLabel;
-    bubble.addEventListener('click', () => openEvent(event.id));
-    bubble.addEventListener('keydown', eventKey => {
-      if (eventKey.key === 'Enter' || eventKey.key === ' ') {
-        eventKey.preventDefault();
-        openEvent(event.id);
-      }
-    });
-
-    if (position === 'left') {
-      leftColumn.appendChild(bubble);
-      rightColumn.classList.add('timeline-entry__column--empty');
-    } else {
-      rightColumn.appendChild(bubble);
-      leftColumn.classList.add('timeline-entry__column--empty');
-    }
-
-    entry.appendChild(leftColumn);
-    entry.appendChild(axisColumn);
-    entry.appendChild(rightColumn);
-
-    eventIndex.set(event.id, { event, century });
-    return entry;
-  }
-
-  const layoutConfig = {
-    step: 28,
-    maxOffset: 180,
-    minScale: 0.65,
-    scaleStep: 0.08,
-    spacing: 14,
-    yearSpacing: 12,
-  };
-
-  let layoutFrame = null;
-
-  function computeAdjustedRect(rect, position, offset, scale) {
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-    const shift = position === 'left' ? -offset : offset;
-    const width = rect.width * scale;
-    const height = rect.height * scale;
-    const left = centerX + shift - width / 2;
-    const top = centerY - height / 2;
-    return {
-      left,
-      right: left + width,
-      top,
-      bottom: top + height,
-    };
-  }
-
-  function rectanglesOverlap(a, b, spacing) {
-    const verticalOverlap = a.bottom > b.top - spacing && a.top < b.bottom + spacing;
-    const horizontalOverlap = a.right > b.left - spacing && a.left < b.right + spacing;
-    return verticalOverlap && horizontalOverlap;
-  }
-
-  function resolveOverlaps(entries) {
-    if (!entries.length) {
+    if (!Array.isArray(data?.centuries)) {
       return [];
     }
-    const data = entries
-      .map(entry => {
-        const bubble = entry.querySelector('.timeline-bubble');
-        if (!bubble) {
-          return null;
-        }
-        const rect = bubble.getBoundingClientRect();
-        const position = entry.dataset.position === 'left' ? 'left' : 'right';
-        return { entry, bubble, rect, position };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.rect.top - b.rect.top);
 
-    const placements = { left: [], right: [] };
-    const adjustments = [];
-
-    data.forEach(item => {
-      const placed = placements[item.position];
-      let offset = 0;
-      let scale = 1;
-      let candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
-      let iterations = 0;
-      const limit = 24;
-
-      while (iterations < limit && placed.some(rect => rectanglesOverlap(rect, candidate, layoutConfig.spacing))) {
-        if (offset < layoutConfig.maxOffset) {
-          offset += layoutConfig.step;
-        } else if (scale > layoutConfig.minScale) {
-          scale = Math.max(layoutConfig.minScale, scale - layoutConfig.scaleStep);
-        } else {
-          offset += layoutConfig.step;
-        }
-        candidate = computeAdjustedRect(item.rect, item.position, offset, scale);
-        iterations += 1;
-      }
-
-      placed.push(candidate);
-      adjustments.push({ entry: item.entry, offset, scale });
-    });
-
-    return adjustments;
-  }
-
-  function spreadYearLabels(entries) {
-    if (!entries.length) {
-      return new Map();
-    }
-
-    const nodes = entries
-      .map(entry => {
-        const year = entry.querySelector('.timeline-year');
-        if (!year) {
-          return null;
-        }
-        return { entry, rect: year.getBoundingClientRect() };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.rect.top - b.rect.top);
-
-    const offsets = new Map();
-    let lastBottom = -Infinity;
-
-    nodes.forEach(item => {
-      const desiredTop = Math.max(item.rect.top, lastBottom + layoutConfig.yearSpacing);
-      const offset = desiredTop - item.rect.top;
-      offsets.set(item.entry, offset);
-      lastBottom = desiredTop + item.rect.height;
-    });
-
-    return offsets;
-  }
-
-  function resetEntryLayout(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
-      return;
-    }
-    const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
-      return;
-    }
-    entries.querySelectorAll('.timeline-entry').forEach(entry => {
-      entry.style.removeProperty('--bubble-offset');
-      entry.style.removeProperty('--bubble-scale');
-      entry.style.removeProperty('--connector-length');
-      entry.style.removeProperty('--entry-y-offset');
-    });
-  }
-
-  function updateConnectorLengths(section) {
-    if (!section || section.classList.contains('timeline-century--collapsed')) {
-      return;
-    }
-    const entries = section.querySelector('.timeline-century__entries');
-    if (!entries || entries.hidden) {
-      return;
-    }
-    const scaleElement = entries.querySelector('.timeline-century__scale');
-    const axisRect = scaleElement ? scaleElement.getBoundingClientRect() : null;
-    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-    entryNodes.forEach(entry => {
-      const bubble = entry.querySelector('.timeline-bubble');
-      if (!bubble) {
-        return;
-      }
-      const bubbleRect = bubble.getBoundingClientRect();
-      const targetNode = entry.querySelector('.timeline-year .timeline-node');
-      const targetRect = targetNode ? targetNode.getBoundingClientRect() : axisRect;
-      if (!targetRect) {
-        return;
-      }
-      const axisCenter = targetRect.left + targetRect.width / 2;
-      const distance = entry.dataset.position === 'left'
-        ? axisCenter - bubbleRect.right
-        : bubbleRect.left - axisCenter;
-      entry.style.setProperty('--connector-length', `${Math.max(distance, 0)}px`);
-    });
-  }
-
-  function applyLayout() {
-    const sections = Array.from(timelineContainer.querySelectorAll('.timeline-century'));
-    sections.forEach(resetEntryLayout);
-
-    requestAnimationFrame(() => {
-      sections.forEach(section => {
-        if (section.classList.contains('timeline-century--collapsed')) {
+    data.centuries.forEach((century, centuryIndex) => {
+      const events = Array.isArray(century?.events) ? century.events : [];
+      events.forEach((event, eventIndex) => {
+        if (!event || !event.id) {
           return;
         }
-        const entries = section.querySelector('.timeline-century__entries');
-        if (!entries || entries.hidden) {
-          return;
+        const label = (typeof event.year === 'string' && event.year.trim()) || 'Undated';
+        const normalized = label.toLowerCase();
+        if (!groups.has(normalized)) {
+          groups.set(normalized, {
+            label,
+            normalized,
+            sortValue: null,
+            events: [],
+            centuries: [],
+          });
         }
-        const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-        const adjustments = resolveOverlaps(entryNodes);
-        const yearOffsets = spreadYearLabels(entryNodes);
-
-        adjustments.forEach(({ entry, offset, scale }) => {
-          entry.style.setProperty('--bubble-offset', `${offset}px`);
-          entry.style.setProperty('--bubble-scale', scale.toFixed(3));
-        });
-
-        entryNodes.forEach(entry => {
-          const yearOffset = yearOffsets.has(entry) ? yearOffsets.get(entry) : 0;
-          entry.style.setProperty('--entry-y-offset', `${yearOffset}px`);
-        });
-      });
-
-      requestAnimationFrame(() => {
-        sections.forEach(updateConnectorLengths);
-      });
-    });
-  }
-
-  function scheduleLayout() {
-    if (layoutFrame) {
-      cancelAnimationFrame(layoutFrame);
-    }
-    layoutFrame = requestAnimationFrame(() => {
-      layoutFrame = null;
-      applyLayout();
-    });
-  }
-
-  function buildCenturySection(century, index) {
-    const section = document.createElement('section');
-    section.className = 'timeline-century';
-
-    const header = document.createElement('div');
-    header.className = 'timeline-century__header';
-
-    const heading = document.createElement('h2');
-    heading.className = 'timeline-century__heading';
-    const headingText = century.title || 'Century of occupation';
-    heading.textContent = century.range ? `${headingText} (${century.range})` : headingText;
-    header.appendChild(heading);
-
-    section.appendChild(header);
-
-    if (century.summary) {
-      const summary = document.createElement('p');
-      summary.className = 'timeline-century__summary';
-      summary.textContent = century.summary;
-      section.appendChild(summary);
-    }
-
-    const entries = document.createElement('div');
-    entries.className = 'timeline-century__entries';
-    const idSeed = (century.id || `century-${index + 1}`).toString();
-    const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-    entries.id = `${normalizedId || `century-${index + 1}`}-entries`;
-
-    const bounds = normalizeCenturyBounds(century);
-    entries.style.setProperty('--century-span', String(bounds.span || 100));
-    buildCenturyScale(entries, bounds);
-
-    const events = Array.isArray(century.events) ? [...century.events] : [];
-    events.sort((a, b) => {
-      const yearA = getEventYearValue(a, bounds);
-      const yearB = getEventYearValue(b, bounds);
-      if (yearA === yearB) {
-        return (a.label || a.id || '').localeCompare(b.label || b.id || '');
-      }
-      return yearA - yearB;
-    });
-    events.forEach(event => {
-      const entry = buildEvent(event, century, bounds);
-      entries.appendChild(entry);
-    });
-
-    section.appendChild(entries);
-    return section;
-  }
-
-  function showEmptyTimelineState() {
-    timelineContainer.innerHTML = '';
-    const empty = document.createElement('p');
-    empty.className = 'text-center text-slate-500 dark:text-slate-300';
-    empty.textContent = 'No timeline entries available.';
-    timelineContainer.appendChild(empty);
-  }
-
-  function displayCentury(value) {
-    if (!Array.isArray(centuriesData) || !centuriesData.length) {
-      showEmptyTimelineState();
-      return;
-    }
-
-    let record = centuriesData.find(entry => entry.value === value);
-    if (!record) {
-      [record] = centuriesData;
-      if (!record) {
-        showEmptyTimelineState();
-        return;
-      }
-      if (centurySelect) {
-        centurySelect.value = record.value;
-      }
-    }
-
-    timelineContainer.innerHTML = '';
-    eventIndex.clear();
-    sharedSidePreference = 'right';
-
-    const section = buildCenturySection(record.century, record.index);
-    timelineContainer.appendChild(section);
-    scheduleLayout();
-  }
-
-  function renderTimeline(data) {
-    const centuries = Array.isArray(data.centuries) ? [...data.centuries].reverse() : [];
-    centuriesData = centuries.map((century, index) => {
-      const idSeed = (century.id || `century-${index + 1}`).toString();
-      const normalizedId = idSeed.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      return {
-        century,
-        index,
-        value: normalizedId || `century-${index + 1}`,
-      };
-    });
-
-    if (centurySelect) {
-      centurySelect.innerHTML = '';
-      if (!centuriesData.length) {
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = 'No centuries available';
-        centurySelect.appendChild(option);
-        centurySelect.disabled = true;
-      } else {
-        centuriesData.forEach(entry => {
-          const option = document.createElement('option');
-          option.value = entry.value;
-          const title = entry.century.title || entry.century.range || `Century ${entry.index + 1}`;
-          if (entry.century.title && entry.century.range) {
-            option.textContent = `${entry.century.title} (${entry.century.range})`;
-          } else {
-            option.textContent = title;
+        const group = groups.get(normalized);
+        const sortValue = getEventYearValue(event);
+        if (Number.isFinite(sortValue)) {
+          if (!Number.isFinite(group.sortValue) || sortValue < group.sortValue) {
+            group.sortValue = sortValue;
           }
-          centurySelect.appendChild(option);
+        }
+        group.events.push({
+          event,
+          century,
+          centuryIndex,
+          eventIndex,
         });
-        centurySelect.disabled = centuriesData.length <= 1;
-      }
-
-      if (centurySelector) {
-        centurySelector.classList.toggle('hidden', !centuriesData.length);
-      }
-
-      centurySelect.onchange = event => {
-        const { value } = event.target;
-        displayCentury(value);
-        try {
-          const url = new URL(window.location.href);
-          if (value) {
-            url.searchParams.set('century', value);
-          } else {
-            url.searchParams.delete('century');
+        if (century) {
+          const signature = `${century.title || ''}__${century.range || ''}`;
+          if (!group.centuries.some(entry => entry.signature === signature)) {
+            group.centuries.push({
+              signature,
+              title: century.title || '',
+              range: century.range || '',
+            });
           }
-          window.history.replaceState(null, '', url);
-        } catch (error) {
-          // ignore URL update issues
         }
-      };
-    }
+      });
+    });
 
-    if (!centuriesData.length) {
-      showEmptyTimelineState();
-      return;
-    }
-
-    let defaultCentury = centuriesData[0];
-    try {
-      const url = new URL(window.location.href);
-      const searchCentury = url.searchParams.get('century');
-      const hashCentury = window.location.hash ? window.location.hash.replace(/^#/, '') : '';
-      const requested = searchCentury || hashCentury || '';
-      if (requested) {
-        const found = centuriesData.find(entry => entry.value === requested);
-        if (found) {
-          defaultCentury = found;
-        }
+    const ordered = Array.from(groups.values());
+    ordered.sort((a, b) => {
+      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.POSITIVE_INFINITY;
+      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.POSITIVE_INFINITY;
+      if (aValue !== bValue) {
+        return aValue - bValue;
       }
-    } catch (error) {
-      // ignore URL parsing issues
-    }
-    if (centurySelect) {
-      centurySelect.value = defaultCentury.value;
-    }
-    displayCentury(defaultCentury.value);
+      return a.label.localeCompare(b.label, undefined, { numeric: true });
+    });
+
+    const usedKeys = new Set();
+    ordered.forEach((group, index) => {
+      const baseKey = sanitizeKey(group.label, `year-${index + 1}`);
+      let candidate = baseKey;
+      let attempt = 2;
+      while (usedKeys.has(candidate)) {
+        candidate = `${baseKey}-${attempt}`;
+        attempt += 1;
+      }
+      group.key = candidate;
+      usedKeys.add(candidate);
+      group.events.sort((a, b) => {
+        const aSort = getEventYearValue(a.event);
+        const bSort = getEventYearValue(b.event);
+        if (Number.isFinite(aSort) && Number.isFinite(bSort) && aSort !== bSort) {
+          return aSort - bSort;
+        }
+        return a.eventIndex - b.eventIndex;
+      });
+    });
+
+    return ordered;
   }
 
-  function renderIntro(data) {
-    if (data.caseTitle) {
+  function updateOverview(data) {
+    if (data.caseTitle && caseTitle) {
       caseTitle.textContent = data.caseTitle;
     }
-    if (data.caseSubtitle) {
-      caseSubtitle.textContent = data.caseSubtitle;
+
+    if (caseSubtitle) {
+      caseSubtitle.textContent = data.caseSubtitle || '';
+      if (data.caseSubtitle) {
+        caseSubtitle.classList.remove('hidden');
+      } else {
+        caseSubtitle.classList.add('hidden');
+      }
     }
 
-    const hasIntro = Array.isArray(data.introduction) && data.introduction.length;
-    caseIntro.innerHTML = '';
-    if (hasIntro) {
-      data.introduction.forEach(paragraph => {
-        const p = document.createElement('p');
-        p.innerHTML = paragraph;
-        caseIntro.appendChild(p);
-      });
-      caseIntro.classList.remove('hidden');
-    } else {
-      caseIntro.classList.add('hidden');
+    if (caseIntro) {
+      caseIntro.innerHTML = '';
+      const introParagraphs = Array.isArray(data.introduction) ? data.introduction : [];
+      if (introParagraphs.length) {
+        introParagraphs.forEach(content => {
+          const paragraph = document.createElement('p');
+          paragraph.innerHTML = content;
+          caseIntro.appendChild(paragraph);
+        });
+        caseIntro.classList.remove('hidden');
+      } else {
+        caseIntro.classList.add('hidden');
+      }
     }
 
-    const hasThemes = Array.isArray(data.keyThemes) && data.keyThemes.length;
-    keyThemes.innerHTML = '';
-    if (hasThemes) {
-      data.keyThemes.forEach(theme => {
-        const card = document.createElement('div');
-        card.className = 'intro-card';
+    if (keyThemes) {
+      keyThemes.innerHTML = '';
+      const themes = Array.isArray(data.keyThemes) ? data.keyThemes : [];
+      if (themes.length) {
+        themes.forEach(theme => {
+          const card = document.createElement('article');
+          card.className = 'key-theme-card';
 
-        const heading = document.createElement('h3');
-        heading.textContent = theme.title;
-        card.appendChild(heading);
+          const heading = document.createElement('h3');
+          heading.textContent = theme.title || 'Theme';
+          card.appendChild(heading);
 
-        if (Array.isArray(theme.items) && theme.items.length) {
-          const list = document.createElement('ul');
-          theme.items.forEach(item => {
-            const li = document.createElement('li');
-            li.textContent = item;
-            list.appendChild(li);
-          });
-          card.appendChild(list);
-        }
+          if (Array.isArray(theme.items) && theme.items.length) {
+            const list = document.createElement('ul');
+            theme.items.forEach(item => {
+              const li = document.createElement('li');
+              li.textContent = item;
+              list.appendChild(li);
+            });
+            card.appendChild(list);
+          }
 
-        keyThemes.appendChild(card);
-      });
-      keyThemes.classList.remove('hidden');
-    } else {
-      keyThemes.classList.add('hidden');
-    }
-
-    if (introPanel && introToggle) {
-      const hasPanelContent = hasIntro || hasThemes;
-      introPanel.classList.add('hidden');
-      introPanel.setAttribute('aria-hidden', 'true');
-      introToggle.setAttribute('aria-expanded', 'false');
-      introToggle.classList.toggle('hidden', !hasPanelContent);
-      introToggle.setAttribute('title', hasPanelContent ? 'About this timeline' : '');
-      if (introClose) {
-        introClose.classList.toggle('hidden', !hasPanelContent);
+          keyThemes.appendChild(card);
+        });
+        keyThemes.classList.remove('hidden');
+      } else {
+        keyThemes.classList.add('hidden');
       }
     }
   }
 
-  function buildContextSection(event) {
-    if (!Array.isArray(event.context) || !event.context.length) {
-      return null;
+  function updateYearMeta(group) {
+    if (!yearMeta) {
+      return;
     }
-    const wrapper = document.createElement('div');
-    const heading = document.createElement('div');
-    heading.className = 'modal-section-heading';
-    heading.textContent = 'Context';
-    wrapper.appendChild(heading);
-
-    const list = document.createElement('ul');
-    list.className = 'modal-context';
-    event.context.forEach(item => {
-      const li = document.createElement('li');
-      li.textContent = item;
-      list.appendChild(li);
-    });
-    wrapper.appendChild(list);
-    return wrapper;
+    if (!group || !group.centuries.length) {
+      yearMeta.textContent = '';
+      yearMeta.classList.add('hidden');
+      return;
+    }
+    const descriptors = group.centuries.map(entry => {
+      if (entry.title && entry.range) {
+        return `${entry.title} (${entry.range})`;
+      }
+      if (entry.title) {
+        return entry.title;
+      }
+      return entry.range || '';
+    }).filter(Boolean);
+    yearMeta.textContent = descriptors.join(' • ');
+    yearMeta.classList.remove('hidden');
   }
 
-  function buildEvidenceSection(event) {
-    if (!Array.isArray(event.evidence) || !event.evidence.length) {
-      return null;
+  function alignYearTrack() {
+    if (!yearViewport || !yearTrack) {
+      return;
     }
-    const wrapper = document.createElement('div');
-    const heading = document.createElement('div');
-    heading.className = 'modal-section-heading';
-    heading.textContent = 'Evidence & records';
-    wrapper.appendChild(heading);
+    const activeButton = yearButtons[activeYearIndex];
+    if (!activeButton) {
+      yearTrack.style.transform = 'translateX(0)';
+      return;
+    }
+    const paddingLeft = parseFloat(getComputedStyle(yearViewport).paddingLeft) || 0;
+    const offset = activeButton.offsetLeft;
+    const translateX = paddingLeft - offset;
+    yearTrack.style.transform = `translateX(${translateX}px)`;
+  }
 
-    const grid = document.createElement('div');
-    grid.className = 'modal-evidence';
+  function alignEntryList() {
+    if (!entryViewport || !entryList) {
+      return;
+    }
+    const activeEntry = entryLinks[activeEntryIndex];
+    if (!activeEntry) {
+      entryList.style.transform = 'translateY(0)';
+      return;
+    }
+    const styles = getComputedStyle(entryViewport);
+    const paddingTop = parseFloat(styles.paddingTop) || 0;
+    const paddingBottom = parseFloat(styles.paddingBottom) || 0;
+    const viewportHeight = entryViewport.clientHeight;
+    const availableHeight = viewportHeight - paddingTop - paddingBottom;
+    const entryHeight = activeEntry.offsetHeight;
+    const focusTop = paddingTop + Math.max(0, availableHeight - entryHeight);
+    const translateY = focusTop - activeEntry.offsetTop;
+    entryList.style.transform = `translateY(${translateY}px)`;
+  }
 
-    event.evidence.forEach(evidence => {
-      const block = document.createElement('article');
-      block.className = 'modal-evidence-item';
+  function updateEntryHighlight(options = {}) {
+    if (!entryLinks.length) {
+      entryList.style.transform = 'translateY(0)';
+      return;
+    }
 
-      const title = document.createElement('h5');
-      title.textContent = evidence.title;
-      block.appendChild(title);
-
-      if (evidence.description) {
-        const description = document.createElement('p');
-        description.textContent = evidence.description;
-        block.appendChild(description);
-      }
-
-      if (Array.isArray(evidence.content) && evidence.content.length) {
-        evidence.content.forEach(paragraph => {
-          const p = document.createElement('p');
-          p.textContent = paragraph;
-          block.appendChild(p);
+    entryLinks.forEach((link, index) => {
+      const isActive = index === activeEntryIndex;
+      link.classList.toggle('is-active', isActive);
+      link.tabIndex = isActive ? 0 : -1;
+      if (isActive && options.focus) {
+        requestAnimationFrame(() => {
+          link.focus();
         });
       }
+    });
+    alignEntryList();
+  }
 
-      if (evidence.embed && evidence.embed.type && evidence.embed.src) {
-        if (evidence.embed.type === 'iframe') {
-          const iframe = document.createElement('iframe');
-          iframe.src = evidence.embed.src;
-          iframe.loading = 'lazy';
-          iframe.title = evidence.embed.title || evidence.title;
-          block.appendChild(iframe);
-        } else if (evidence.embed.type === 'object') {
-          const object = document.createElement('object');
-          object.data = evidence.embed.src;
-          object.type = evidence.embed.mime || 'application/pdf';
-          block.appendChild(object);
-        }
+  function renderEntries(group) {
+    entryList.innerHTML = '';
+    entryList.style.transform = 'translateY(0)';
+    entryLinks = [];
+    if (!group) {
+      return;
+    }
+    group.events.forEach(({ event }) => {
+      const card = document.createElement('a');
+      card.className = 'entry-card';
+      card.href = `entries/${event.id}.html`;
+      card.setAttribute('role', 'menuitem');
+      card.tabIndex = -1;
+
+      const heading = document.createElement('h3');
+      heading.textContent = event.title || 'Timeline entry';
+      card.appendChild(heading);
+
+      if (event.summary) {
+        const summary = document.createElement('p');
+        summary.textContent = event.summary;
+        card.appendChild(summary);
       }
 
-      if (evidence.source && (evidence.source.name || evidence.source.url)) {
-        const meta = document.createElement('p');
-        meta.className = 'modal-evidence-meta';
-        if (evidence.source.url) {
-          const link = document.createElement('a');
-          link.href = evidence.source.url;
-          link.target = '_blank';
-          link.rel = 'noopener';
-          link.textContent = evidence.source.name || evidence.source.url;
-          meta.appendChild(document.createTextNode('Source: '));
-          meta.appendChild(link);
+      entryList.appendChild(card);
+      entryLinks.push(card);
+    });
+
+    activeEntryIndex = 0;
+    updateEntryHighlight();
+  }
+
+  function updateYearButtons() {
+    yearButtons.forEach((button, index) => {
+      const isActive = index === activeYearIndex;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.tabIndex = isActive ? 0 : -1;
+      if (isActive) {
+        button.focus();
+      }
+    });
+    alignYearTrack();
+  }
+
+  function activateYear(nextIndex, options = {}) {
+    if (!yearGroups.length) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(yearGroups.length - 1, nextIndex));
+    const changed = clamped !== activeYearIndex;
+    activeYearIndex = clamped;
+
+    if (changed || options.force) {
+      updateYearButtons();
+    } else if (options.focusYear) {
+      const activeButton = yearButtons[activeYearIndex];
+      if (activeButton) {
+        activeButton.focus();
+      }
+    }
+
+    const group = yearGroups[activeYearIndex];
+    if (yearTitle) {
+      yearTitle.textContent = group ? group.label : '';
+    }
+    updateYearMeta(group);
+    renderEntries(group);
+
+    const shouldFocusEntry = Boolean(options.focusEntry);
+    updateEntryHighlight({ focus: shouldFocusEntry && entryLinks.length > 0 });
+  }
+
+  function changeEntry(delta, { focus = true } = {}) {
+    if (!entryLinks.length) {
+      return;
+    }
+    const next = Math.max(0, Math.min(entryLinks.length - 1, activeEntryIndex + delta));
+    if (next === activeEntryIndex) {
+      return;
+    }
+    activeEntryIndex = next;
+    updateEntryHighlight({ focus });
+  }
+
+  function handleKeyboard(event) {
+    const target = event.target;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        if (!yearGroups.length) {
+          return;
+        }
+        event.preventDefault();
+        const nextIndex = Math.min(yearGroups.length - 1, activeYearIndex + 1);
+        if (nextIndex !== activeYearIndex) {
+          activateYear(nextIndex, { focusYear: true });
+        }
+        break;
+      }
+      case 'ArrowLeft': {
+        if (!yearGroups.length) {
+          return;
+        }
+        event.preventDefault();
+        const nextIndex = Math.max(0, activeYearIndex - 1);
+        if (nextIndex !== activeYearIndex) {
+          activateYear(nextIndex, { focusYear: true });
+        }
+        break;
+      }
+      case 'ArrowDown': {
+        if (!entryLinks.length) {
+          return;
+        }
+        event.preventDefault();
+        if (document.activeElement && yearButtons.includes(document.activeElement)) {
+          updateEntryHighlight({ focus: true });
         } else {
-          meta.textContent = `Source: ${evidence.source.name}`;
+          changeEntry(1, { focus: true });
         }
-        block.appendChild(meta);
+        break;
       }
-
-      grid.appendChild(block);
-    });
-
-    wrapper.appendChild(grid);
-    return wrapper;
-  }
-
-  function openEvent(eventId) {
-    if (!modal) {
-      return;
-    }
-    const record = eventIndex.get(eventId);
-    if (!record) {
-      return;
-    }
-    const { event, century } = record;
-    modalTitle.textContent = event.title;
-
-    if (century) {
-      const details = [century.title, century.range, event.year].filter(Boolean).join(' • ');
-      modalSource.textContent = details;
-    } else {
-      modalSource.textContent = event.year || '';
-    }
-
-    if (event.summary) {
-      modalDescription.classList.remove('hidden');
-      modalDescription.innerHTML = '';
-      const summary = document.createElement('span');
-      summary.className = 'modal-summary-text';
-      summary.innerHTML = event.summary;
-      modalDescription.appendChild(summary);
-
-      const learnMoreLink = document.createElement('a');
-      learnMoreLink.className = 'modal-learn-more';
-      learnMoreLink.href = `entries/${encodeURIComponent(event.id)}.html`;
-      learnMoreLink.textContent = 'Learn more';
-      modalDescription.appendChild(learnMoreLink);
-    } else {
-      modalDescription.innerHTML = '';
-      modalDescription.classList.add('hidden');
-    }
-
-    modalBody.innerHTML = '';
-
-    const contextSection = buildContextSection(event);
-    if (contextSection) {
-      modalBody.appendChild(contextSection);
-    }
-
-    const evidenceSection = buildEvidenceSection(event);
-    if (evidenceSection) {
-      modalBody.appendChild(evidenceSection);
-    }
-
-    modal.classList.add('active');
-    modal.setAttribute('aria-hidden', 'false');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeModal() {
-    if (!modal) {
-      return;
-    }
-    modal.classList.remove('active');
-    modal.setAttribute('aria-hidden', 'true');
-    document.body.style.overflow = '';
-  }
-
-  if (closeBtn) {
-    closeBtn.addEventListener('click', closeModal);
-  }
-
-  if (modal) {
-    modal.addEventListener('click', event => {
-      if (event.target === modal) {
-        closeModal();
+      case 'ArrowUp': {
+        if (!entryLinks.length) {
+          return;
+        }
+        event.preventDefault();
+        if (document.activeElement && entryLinks.includes(document.activeElement)) {
+          changeEntry(-1, { focus: true });
+        } else {
+          const activeButton = yearButtons[activeYearIndex];
+          if (activeButton) {
+            activeButton.focus();
+          }
+        }
+        break;
       }
+      default:
+    }
+  }
+
+  document.addEventListener('keydown', handleKeyboard);
+
+  function hideLoading() {
+    if (loadingBanner) {
+      loadingBanner.classList.add('hidden');
+    }
+  }
+
+  function showLoadingMessage(message) {
+    if (loadingBanner) {
+      loadingBanner.textContent = message;
+      loadingBanner.classList.remove('hidden');
+    }
+  }
+
+  function renderYearBar(groups) {
+    yearTrack.innerHTML = '';
+    yearButtons = groups.map((group, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'year-item';
+      button.textContent = group.label;
+      button.dataset.yearKey = group.key;
+      button.setAttribute('role', 'option');
+      button.setAttribute('aria-selected', 'false');
+      button.tabIndex = index === 0 ? 0 : -1;
+      button.addEventListener('click', () => {
+        activateYear(index, { focusYear: true });
+      });
+      yearTrack.appendChild(button);
+      return button;
     });
-  }
-
-  document.addEventListener('keydown', event => {
-    if (event.key === 'Escape' && modal && modal.classList.contains('active')) {
-      closeModal();
-    }
-  });
-
-  function updateIntroState(nextState) {
-    if (!introToggle || !introPanel) {
-      return;
-    }
-    introToggle.setAttribute('aria-expanded', String(nextState));
-    introPanel.classList.toggle('hidden', !nextState);
-    introPanel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
-    introToggle.setAttribute('title', nextState ? 'Hide timeline introduction' : 'About this timeline');
-    if (nextState) {
-      introPanel.focus();
-      introPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }
-
-  if (introToggle && introPanel) {
-    introToggle.addEventListener('click', () => {
-      const isExpanded = introToggle.getAttribute('aria-expanded') === 'true';
-      updateIntroState(!isExpanded);
-    });
-  }
-
-  if (introClose) {
-    introClose.addEventListener('click', () => updateIntroState(false));
-  }
-
-  const handleWindowResize = () => scheduleLayout();
-  window.addEventListener('resize', handleWindowResize);
-  window.addEventListener('orientationchange', handleWindowResize);
-
-  const timelineLayoutObserver = typeof ResizeObserver !== 'undefined' && timelineContainer
-    ? new ResizeObserver(() => scheduleLayout())
-    : null;
-  if (timelineLayoutObserver) {
-    timelineLayoutObserver.observe(timelineContainer);
-  }
-
-  if (document.fonts && document.fonts.ready) {
-    document.fonts.ready.then(() => scheduleLayout());
   }
 
   fetch('data/timeline.json')
@@ -922,13 +501,18 @@
       return response.json();
     })
     .then(data => {
-      loadingMessage.classList.add('hidden');
-      renderIntro(data);
-      renderTimeline(data);
+      updateOverview(data);
+      yearGroups = buildYearGroups(data);
+      if (!yearGroups.length) {
+        showLoadingMessage('No timeline data available.');
+        return;
+      }
+      renderYearBar(yearGroups);
+      hideLoading();
+      activateYear(0, { focusYear: true, force: true });
     })
     .catch(error => {
       console.error(error);
-      loadingMessage.textContent = 'We could not load the timeline data. Please refresh the page.';
+      showLoadingMessage('We could not load the timeline data. Please refresh the page.');
     });
 })();
-

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -1,104 +1,57 @@
 (function () {
-  const body = document.body;
-  const themeToggle = document.getElementById('theme-toggle');
-  const themeIcon = themeToggle ? themeToggle.querySelector('[data-theme-icon]') : null;
-  const caseTitle = document.getElementById('case-title');
-  const caseSubtitle = document.getElementById('case-subtitle');
-  const caseIntro = document.getElementById('case-intro');
-  const keyThemes = document.getElementById('key-themes');
   const yearTrack = document.getElementById('timeline-year-track');
   const yearViewport = document.getElementById('year-bar-viewport');
-  const loadingBanner = document.getElementById('timeline-loading');
-  const yearTitle = document.getElementById('timeline-year-title');
-  const yearMeta = document.getElementById('timeline-year-meta');
   const entryViewport = document.getElementById('timeline-entry-viewport');
   const entryList = document.getElementById('timeline-year-entries');
+  const loadingBanner = document.getElementById('timeline-loading');
 
-  const storageKey = 'ghf-theme';
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  if (!yearTrack || !entryViewport || !entryList) {
+    return;
+  }
 
   let yearGroups = [];
   let yearButtons = [];
-  let entryLinks = [];
+  let entryItems = [];
   let activeYearIndex = 0;
   let activeEntryIndex = 0;
+  let suppressFocusSync = false;
 
-  function setTheme(theme, persist = true) {
-    const normalized = theme === 'dark' ? 'dark' : 'light';
-    body.dataset.theme = normalized;
-    if (themeToggle) {
-      themeToggle.setAttribute('aria-pressed', normalized === 'dark' ? 'true' : 'false');
-      themeToggle.setAttribute('title', normalized === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+  function limitWords(value, maxWords) {
+    if (!value) {
+      return '';
     }
-    if (themeIcon) {
-      themeIcon.textContent = normalized === 'dark' ? '🌙' : '☀️';
-    }
-    if (persist) {
-      try {
-        localStorage.setItem(storageKey, normalized);
-      } catch (error) {
-        // ignore persistence errors
-      }
-    }
+    const words = String(value).trim().split(/\s+/);
+    return words.slice(0, Math.max(1, maxWords)).join(' ');
   }
 
-  const savedTheme = (() => {
-    try {
-      return localStorage.getItem(storageKey);
-    } catch (error) {
-      return null;
+  function getYearSubtitle(group) {
+    if (!group || !group.events.length) {
+      return '';
     }
-  })();
-
-  if (savedTheme) {
-    setTheme(savedTheme, false);
-  } else {
-    setTheme(prefersDark.matches ? 'dark' : 'light', false);
+    const primaryEvent = group.events[0].event;
+    const subtitleSource = primaryEvent.iconLabel || primaryEvent.title || primaryEvent.year || '';
+    return limitWords(subtitleSource, 4);
   }
 
-  if (themeToggle) {
-    themeToggle.addEventListener('click', () => {
-      const next = body.dataset.theme === 'dark' ? 'light' : 'dark';
-      setTheme(next, true);
-    });
-  }
-
-  prefersDark.addEventListener('change', event => {
-    try {
-      if (!localStorage.getItem(storageKey)) {
-        setTheme(event.matches ? 'dark' : 'light', false);
-      }
-    } catch (error) {
-      setTheme(event.matches ? 'dark' : 'light', false);
+  function getEventSubtitle(event) {
+    if (!event) {
+      return '';
     }
-  });
-
-  function getEventYearValue(event) {
-    const direct = Number(event?.yearValue);
-    if (Number.isFinite(direct)) {
-      return direct;
+    if (event.summary) {
+      return limitWords(event.summary, 4);
     }
-    const match = typeof event?.year === 'string' ? event.year.match(/(1[0-9]{3}|20[0-9]{2})/) : null;
-    if (match) {
-      return Number(match[0]);
+    if (event.title) {
+      return limitWords(event.title, 4);
     }
-    return null;
-  }
-
-  function sanitizeKey(value, fallback) {
-    const base = String(value || '')
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '');
-    return base || fallback;
+    return limitWords(event.year, 4);
   }
 
   function buildYearGroups(data) {
-    const groups = new Map();
-
     if (!Array.isArray(data?.centuries)) {
       return [];
     }
+
+    const groups = new Map();
 
     data.centuries.forEach((century, centuryIndex) => {
       const events = Array.isArray(century?.events) ? century.events : [];
@@ -107,21 +60,20 @@
           return;
         }
         const label = (typeof event.year === 'string' && event.year.trim()) || 'Undated';
-        const normalized = label.toLowerCase();
-        if (!groups.has(normalized)) {
-          groups.set(normalized, {
+        const key = label.toLowerCase();
+        if (!groups.has(key)) {
+          groups.set(key, {
             label,
-            normalized,
-            sortValue: null,
+            key,
             events: [],
-            centuries: [],
+            sortValue: Number.isFinite(event.yearValue) ? event.yearValue : null,
           });
         }
-        const group = groups.get(normalized);
-        const sortValue = getEventYearValue(event);
-        if (Number.isFinite(sortValue)) {
-          if (!Number.isFinite(group.sortValue) || sortValue < group.sortValue) {
-            group.sortValue = sortValue;
+        const group = groups.get(key);
+        const yearValue = Number.isFinite(event.yearValue) ? event.yearValue : null;
+        if (Number.isFinite(yearValue)) {
+          if (!Number.isFinite(group.sortValue) || yearValue < group.sortValue) {
+            group.sortValue = yearValue;
           }
         }
         group.events.push({
@@ -130,16 +82,6 @@
           centuryIndex,
           eventIndex,
         });
-        if (century) {
-          const signature = `${century.title || ''}__${century.range || ''}`;
-          if (!group.centuries.some(entry => entry.signature === signature)) {
-            group.centuries.push({
-              signature,
-              title: century.title || '',
-              range: century.range || '',
-            });
-          }
-        }
       });
     });
 
@@ -153,255 +95,239 @@
       return a.label.localeCompare(b.label, undefined, { numeric: true });
     });
 
-    const usedKeys = new Set();
     ordered.forEach((group, index) => {
-      const baseKey = sanitizeKey(group.label, `year-${index + 1}`);
-      let candidate = baseKey;
-      let attempt = 2;
-      while (usedKeys.has(candidate)) {
-        candidate = `${baseKey}-${attempt}`;
-        attempt += 1;
-      }
-      group.key = candidate;
-      usedKeys.add(candidate);
       group.events.sort((a, b) => {
-        const aSort = getEventYearValue(a.event);
-        const bSort = getEventYearValue(b.event);
-        if (Number.isFinite(aSort) && Number.isFinite(bSort) && aSort !== bSort) {
-          return aSort - bSort;
+        const aValue = Number.isFinite(a.event.yearValue) ? a.event.yearValue : Number.POSITIVE_INFINITY;
+        const bValue = Number.isFinite(b.event.yearValue) ? b.event.yearValue : Number.POSITIVE_INFINITY;
+        if (aValue !== bValue) {
+          return aValue - bValue;
         }
         return a.eventIndex - b.eventIndex;
       });
+      const primaryEventWithIcon = group.events.find(entry => entry.event.icon);
+      group.icon = primaryEventWithIcon?.event?.icon || '🕰️';
+      group.title = limitWords(group.label, 2) || `Year ${index + 1}`;
+      group.subtitle = getYearSubtitle(group);
     });
 
     return ordered;
   }
 
-  function updateOverview(data) {
-    if (data.caseTitle && caseTitle) {
-      caseTitle.textContent = data.caseTitle;
-    }
-
-    if (caseSubtitle) {
-      caseSubtitle.textContent = data.caseSubtitle || '';
-      if (data.caseSubtitle) {
-        caseSubtitle.classList.remove('hidden');
-      } else {
-        caseSubtitle.classList.add('hidden');
-      }
-    }
-
-    if (caseIntro) {
-      caseIntro.innerHTML = '';
-      const introParagraphs = Array.isArray(data.introduction) ? data.introduction : [];
-      if (introParagraphs.length) {
-        introParagraphs.forEach(content => {
-          const paragraph = document.createElement('p');
-          paragraph.innerHTML = content;
-          caseIntro.appendChild(paragraph);
-        });
-        caseIntro.classList.remove('hidden');
-      } else {
-        caseIntro.classList.add('hidden');
-      }
-    }
-
-    if (keyThemes) {
-      keyThemes.innerHTML = '';
-      const themes = Array.isArray(data.keyThemes) ? data.keyThemes : [];
-      if (themes.length) {
-        themes.forEach(theme => {
-          const card = document.createElement('article');
-          card.className = 'key-theme-card';
-
-          const heading = document.createElement('h3');
-          heading.textContent = theme.title || 'Theme';
-          card.appendChild(heading);
-
-          if (Array.isArray(theme.items) && theme.items.length) {
-            const list = document.createElement('ul');
-            theme.items.forEach(item => {
-              const li = document.createElement('li');
-              li.textContent = item;
-              list.appendChild(li);
-            });
-            card.appendChild(list);
-          }
-
-          keyThemes.appendChild(card);
-        });
-        keyThemes.classList.remove('hidden');
-      } else {
-        keyThemes.classList.add('hidden');
-      }
+  function hideLoading() {
+    if (loadingBanner) {
+      loadingBanner.classList.add('is-hidden');
     }
   }
 
-  function updateYearMeta(group) {
-    if (!yearMeta) {
-      return;
+  function showLoading(message) {
+    if (loadingBanner) {
+      loadingBanner.textContent = message;
+      loadingBanner.classList.remove('is-hidden');
     }
-    if (!group || !group.centuries.length) {
-      yearMeta.textContent = '';
-      yearMeta.classList.add('hidden');
-      return;
-    }
-    const descriptors = group.centuries.map(entry => {
-      if (entry.title && entry.range) {
-        return `${entry.title} (${entry.range})`;
-      }
-      if (entry.title) {
-        return entry.title;
-      }
-      return entry.range || '';
-    }).filter(Boolean);
-    yearMeta.textContent = descriptors.join(' • ');
-    yearMeta.classList.remove('hidden');
+  }
+
+  function clearEntryList() {
+    entryList.innerHTML = '';
+    entryList.style.transform = 'translateY(0)';
+    entryItems = [];
   }
 
   function alignYearTrack() {
-    if (!yearViewport || !yearTrack) {
-      return;
-    }
     const activeButton = yearButtons[activeYearIndex];
     if (!activeButton) {
       yearTrack.style.transform = 'translateX(0)';
       return;
     }
-    const paddingLeft = parseFloat(getComputedStyle(yearViewport).paddingLeft) || 0;
+
     const offset = activeButton.offsetLeft;
-    const translateX = paddingLeft - offset;
-    yearTrack.style.transform = `translateX(${translateX}px)`;
+    const viewportWidth = yearViewport?.clientWidth || 0;
+    const trackWidth = yearTrack.scrollWidth;
+    const maxTranslate = 0;
+    const minTranslate = Math.min(0, viewportWidth - trackWidth);
+    const desired = -offset;
+    const clamped = Math.max(minTranslate, Math.min(maxTranslate, desired));
+    yearTrack.style.transform = `translateX(${clamped}px)`;
   }
 
   function alignEntryList() {
-    if (!entryViewport || !entryList) {
-      return;
-    }
-    const activeEntry = entryLinks[activeEntryIndex];
+    const activeEntry = entryItems[activeEntryIndex];
     if (!activeEntry) {
       entryList.style.transform = 'translateY(0)';
       return;
     }
-    const styles = getComputedStyle(entryViewport);
-    const paddingTop = parseFloat(styles.paddingTop) || 0;
-    const paddingBottom = parseFloat(styles.paddingBottom) || 0;
-    const viewportHeight = entryViewport.clientHeight;
-    const availableHeight = viewportHeight - paddingTop - paddingBottom;
-    const entryHeight = activeEntry.offsetHeight;
-    const focusTop = paddingTop + Math.max(0, availableHeight - entryHeight);
-    const translateY = focusTop - activeEntry.offsetTop;
-    entryList.style.transform = `translateY(${translateY}px)`;
+    const offset = activeEntry.offsetTop;
+    const viewportHeight = entryViewport?.clientHeight || 0;
+    const listHeight = entryList.scrollHeight;
+    const activeHeight = activeEntry.offsetHeight;
+    const focusOffset = Math.max(0, viewportHeight - activeHeight);
+    const desired = focusOffset - offset;
+    const minTranslate = Math.min(0, viewportHeight - listHeight);
+    const maxTranslate = Math.max(0, focusOffset);
+    const clamped = Math.max(minTranslate, Math.min(maxTranslate, desired));
+    entryList.style.transform = `translateY(${clamped}px)`;
   }
 
-  function updateEntryHighlight(options = {}) {
-    if (!entryLinks.length) {
+  function setActiveEntry(index, { focus = false } = {}) {
+    if (!entryItems.length) {
       entryList.style.transform = 'translateY(0)';
       return;
     }
-
-    entryLinks.forEach((link, index) => {
-      const isActive = index === activeEntryIndex;
-      link.classList.toggle('is-active', isActive);
-      link.tabIndex = isActive ? 0 : -1;
-      if (isActive && options.focus) {
+    const clamped = Math.max(0, Math.min(entryItems.length - 1, index));
+    activeEntryIndex = clamped;
+    entryItems.forEach((item, itemIndex) => {
+      const isActive = itemIndex === activeEntryIndex;
+      item.classList.toggle('is-active', isActive);
+      item.tabIndex = isActive ? 0 : -1;
+      if (isActive && focus) {
         requestAnimationFrame(() => {
-          link.focus();
+          item.focus({ preventScroll: true });
         });
       }
     });
     alignEntryList();
   }
 
-  function renderEntries(group) {
-    entryList.innerHTML = '';
-    entryList.style.transform = 'translateY(0)';
-    entryLinks = [];
-    if (!group) {
+  function renderEntryList(group) {
+    clearEntryList();
+    if (!group || !group.events.length) {
       return;
     }
+
     group.events.forEach(({ event }) => {
-      const card = document.createElement('a');
-      card.className = 'entry-card';
-      card.href = `entries/${event.id}.html`;
-      card.setAttribute('role', 'menuitem');
-      card.tabIndex = -1;
+      const link = document.createElement('a');
+      link.className = 'xmb-entry';
+      link.href = `entries/${event.id}.html`;
+      link.setAttribute('role', 'menuitem');
+      link.setAttribute('aria-label', event.title || event.year || 'Timeline entry');
+      link.tabIndex = -1;
 
-      const heading = document.createElement('h3');
-      heading.textContent = event.title || 'Timeline entry';
-      card.appendChild(heading);
+      const icon = document.createElement('span');
+      icon.className = 'xmb-entry__icon';
+      icon.textContent = event.icon || '📘';
+      link.appendChild(icon);
 
-      if (event.summary) {
-        const summary = document.createElement('p');
-        summary.textContent = event.summary;
-        card.appendChild(summary);
+      const copy = document.createElement('span');
+      copy.className = 'xmb-entry__copy';
+
+      const title = document.createElement('span');
+      title.className = 'xmb-entry__title';
+      title.textContent = limitWords(event.iconLabel || event.title || event.year || 'Entry', 2);
+      copy.appendChild(title);
+
+      const subtitleText = getEventSubtitle(event);
+      if (subtitleText) {
+        const subtitle = document.createElement('span');
+        subtitle.className = 'xmb-entry__subtitle';
+        subtitle.textContent = subtitleText;
+        copy.appendChild(subtitle);
       }
 
-      entryList.appendChild(card);
-      entryLinks.push(card);
+      link.appendChild(copy);
+
+      link.addEventListener('focus', () => {
+        const index = entryItems.indexOf(link);
+        if (index >= 0) {
+          activeEntryIndex = index;
+          alignEntryList();
+          entryItems.forEach((item, idx) => {
+            item.classList.toggle('is-active', idx === index);
+            item.tabIndex = idx === index ? 0 : -1;
+          });
+        }
+      });
+
+      entryList.appendChild(link);
+      entryItems.push(link);
     });
 
-    activeEntryIndex = 0;
-    updateEntryHighlight();
+    setActiveEntry(0);
   }
 
-  function updateYearButtons() {
-    yearButtons.forEach((button, index) => {
-      const isActive = index === activeYearIndex;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
-      button.tabIndex = isActive ? 0 : -1;
-      if (isActive) {
-        button.focus();
-      }
-    });
-    alignYearTrack();
-  }
-
-  function activateYear(nextIndex, options = {}) {
+  function setActiveYear(index, { focusYear = false } = {}) {
     if (!yearGroups.length) {
       return;
     }
-    const clamped = Math.max(0, Math.min(yearGroups.length - 1, nextIndex));
-    const changed = clamped !== activeYearIndex;
+    const clamped = Math.max(0, Math.min(yearGroups.length - 1, index));
+    if (clamped === activeYearIndex && !focusYear) {
+      return;
+    }
     activeYearIndex = clamped;
-
-    if (changed || options.force) {
-      updateYearButtons();
-    } else if (options.focusYear) {
-      const activeButton = yearButtons[activeYearIndex];
-      if (activeButton) {
-        activeButton.focus();
-      }
-    }
-
     const group = yearGroups[activeYearIndex];
-    if (yearTitle) {
-      yearTitle.textContent = group ? group.label : '';
-    }
-    updateYearMeta(group);
-    renderEntries(group);
 
-    const shouldFocusEntry = Boolean(options.focusEntry);
-    updateEntryHighlight({ focus: shouldFocusEntry && entryLinks.length > 0 });
+    yearButtons.forEach((button, buttonIndex) => {
+      const isActive = buttonIndex === activeYearIndex;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.tabIndex = isActive ? 0 : -1;
+      if (isActive && focusYear && !suppressFocusSync) {
+        requestAnimationFrame(() => {
+          button.focus({ preventScroll: true });
+        });
+      }
+    });
+
+    alignYearTrack();
+    renderEntryList(group);
   }
 
-  function changeEntry(delta, { focus = true } = {}) {
-    if (!entryLinks.length) {
-      return;
-    }
-    const next = Math.max(0, Math.min(entryLinks.length - 1, activeEntryIndex + delta));
-    if (next === activeEntryIndex) {
-      return;
-    }
-    activeEntryIndex = next;
-    updateEntryHighlight({ focus });
+  function renderYearButtons(groups) {
+    yearTrack.innerHTML = '';
+    yearButtons = groups.map((group, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'xmb-year';
+      button.dataset.yearKey = group.key;
+      button.setAttribute('role', 'option');
+      button.setAttribute('aria-selected', 'false');
+      button.setAttribute('aria-label', group.label);
+      button.tabIndex = index === 0 ? 0 : -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'xmb-year__icon';
+      icon.textContent = group.icon;
+      button.appendChild(icon);
+
+      const copy = document.createElement('span');
+      copy.className = 'xmb-year__copy';
+
+      const title = document.createElement('span');
+      title.className = 'xmb-year__title';
+      title.textContent = limitWords(group.label, 2) || `Year ${index + 1}`;
+      copy.appendChild(title);
+
+      const subtitleText = group.subtitle;
+      if (subtitleText) {
+        const subtitle = document.createElement('span');
+        subtitle.className = 'xmb-year__subtitle';
+        subtitle.textContent = subtitleText;
+        copy.appendChild(subtitle);
+      }
+
+      button.appendChild(copy);
+
+      button.addEventListener('click', () => {
+        setActiveYear(index, { focusYear: true });
+      });
+
+      button.addEventListener('focus', () => {
+        if (suppressFocusSync) {
+          return;
+        }
+        setActiveYear(index, { focusYear: false });
+      });
+
+      yearTrack.appendChild(button);
+      return button;
+    });
   }
 
-  function handleKeyboard(event) {
+  function handleKeydown(event) {
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
     const target = event.target;
-    const tag = target?.tagName;
-    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable) {
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
       return;
     }
 
@@ -411,10 +337,8 @@
           return;
         }
         event.preventDefault();
-        const nextIndex = Math.min(yearGroups.length - 1, activeYearIndex + 1);
-        if (nextIndex !== activeYearIndex) {
-          activateYear(nextIndex, { focusYear: true });
-        }
+        const next = Math.min(yearGroups.length - 1, activeYearIndex + 1);
+        setActiveYear(next, { focusYear: true });
         break;
       }
       case 'ArrowLeft': {
@@ -422,35 +346,44 @@
           return;
         }
         event.preventDefault();
-        const nextIndex = Math.max(0, activeYearIndex - 1);
-        if (nextIndex !== activeYearIndex) {
-          activateYear(nextIndex, { focusYear: true });
-        }
+        const next = Math.max(0, activeYearIndex - 1);
+        setActiveYear(next, { focusYear: true });
         break;
       }
       case 'ArrowDown': {
-        if (!entryLinks.length) {
+        if (!entryItems.length) {
           return;
         }
         event.preventDefault();
         if (document.activeElement && yearButtons.includes(document.activeElement)) {
-          updateEntryHighlight({ focus: true });
+          setActiveEntry(0, { focus: true });
         } else {
-          changeEntry(1, { focus: true });
+          setActiveEntry(activeEntryIndex + 1, { focus: true });
         }
         break;
       }
       case 'ArrowUp': {
-        if (!entryLinks.length) {
+        if (!entryItems.length) {
           return;
         }
         event.preventDefault();
-        if (document.activeElement && entryLinks.includes(document.activeElement)) {
-          changeEntry(-1, { focus: true });
+        if (document.activeElement && entryItems.includes(document.activeElement)) {
+          if (activeEntryIndex === 0) {
+            const activeButton = yearButtons[activeYearIndex];
+            if (activeButton) {
+              suppressFocusSync = true;
+              activeButton.focus({ preventScroll: true });
+              suppressFocusSync = false;
+            }
+          } else {
+            setActiveEntry(activeEntryIndex - 1, { focus: true });
+          }
         } else {
           const activeButton = yearButtons[activeYearIndex];
           if (activeButton) {
-            activeButton.focus();
+            suppressFocusSync = true;
+            activeButton.focus({ preventScroll: true });
+            suppressFocusSync = false;
           }
         }
         break;
@@ -459,39 +392,13 @@
     }
   }
 
-  document.addEventListener('keydown', handleKeyboard);
-
-  function hideLoading() {
-    if (loadingBanner) {
-      loadingBanner.classList.add('hidden');
-    }
+  function handleResize() {
+    alignYearTrack();
+    alignEntryList();
   }
 
-  function showLoadingMessage(message) {
-    if (loadingBanner) {
-      loadingBanner.textContent = message;
-      loadingBanner.classList.remove('hidden');
-    }
-  }
-
-  function renderYearBar(groups) {
-    yearTrack.innerHTML = '';
-    yearButtons = groups.map((group, index) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'year-item';
-      button.textContent = group.label;
-      button.dataset.yearKey = group.key;
-      button.setAttribute('role', 'option');
-      button.setAttribute('aria-selected', 'false');
-      button.tabIndex = index === 0 ? 0 : -1;
-      button.addEventListener('click', () => {
-        activateYear(index, { focusYear: true });
-      });
-      yearTrack.appendChild(button);
-      return button;
-    });
-  }
+  document.addEventListener('keydown', handleKeydown);
+  window.addEventListener('resize', handleResize);
 
   fetch('data/timeline.json')
     .then(response => {
@@ -501,18 +408,19 @@
       return response.json();
     })
     .then(data => {
-      updateOverview(data);
       yearGroups = buildYearGroups(data);
       if (!yearGroups.length) {
-        showLoadingMessage('No timeline data available.');
+        showLoading('No timeline data available.');
         return;
       }
-      renderYearBar(yearGroups);
+      renderYearButtons(yearGroups);
       hideLoading();
-      activateYear(0, { focusYear: true, force: true });
+      requestAnimationFrame(() => {
+        setActiveYear(0, { focusYear: true });
+      });
     })
     .catch(error => {
       console.error(error);
-      showLoadingMessage('We could not load the timeline data. Please refresh the page.');
+      showLoading('We could not load the timeline data. Please refresh the page.');
     });
 })();


### PR DESCRIPTION
## Summary
- replace the timeline page with an XMB-inspired layout featuring a bottom-aligned horizontal year rail, fading viewport, and vertical entry panel
- rewrite the timeline script to group events by year, drive the new navigation, and provide keyboard controls linking the horizontal and vertical menus
- style the entry detail pages with a prominent fixed back button

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef0f43c7b48320bfee2f4f3eab4e34