### PR TITLE
Add menu configuration for timeline navigation

### DIFF
--- a/static/bpvsbuckler/data/menu.json
+++ b/static/bpvsbuckler/data/menu.json
@@ -1,0 +1,202 @@
+{
+  "entries": [
+    {
+      "key": "1994",
+      "text": "1994",
+      "icon": "🏺",
+      "ariaLabel": "Excavation uncovers an early-medieval cemetery beneath the farm"
+    },
+    {
+      "key": "1991",
+      "text": "1991",
+      "icon": "📚",
+      "ariaLabel": "Academic commentary consolidates the precedent"
+    },
+    {
+      "key": "1990",
+      "text": "1990",
+      "icon": "🧭",
+      "ariaLabel": "Archaeologists survey the cleared site ahead of redevelopment"
+    },
+    {
+      "key": "1980s",
+      "text": "1980s",
+      "icon": "👪",
+      "ariaLabel": "Twentieth-century battles end in the Court of Appeal"
+    },
+    {
+      "key": "1988",
+      "text": "1988",
+      "icon": "🏚️",
+      "ariaLabel": "Great House Farm is demolished after 33 years of dispute"
+    },
+    {
+      "key": "1987",
+      "text": "1987",
+      "icon": "⚖️",
+      "ariaLabel": "Court of Appeal dismisses William Buckler's appeal"
+    },
+    {
+      "key": "1985",
+      "text": "1985",
+      "icon": "⚖️",
+      "ariaLabel": "County court finds licence defeats adverse possession"
+    },
+    {
+      "key": "1983",
+      "text": "1983",
+      "icon": "🕯️",
+      "ariaLabel": "Mary Buckler's passing leaves her son to continue the fight"
+    },
+    {
+      "key": "1979",
+      "text": "1979",
+      "icon": "🏺",
+      "ariaLabel": "Roman villa remains are discovered on former Great House Farm land"
+    },
+    {
+      "key": "1976",
+      "text": "1976",
+      "icon": "🏛️",
+      "ariaLabel": "Case raised in the House of Commons"
+    },
+    {
+      "key": "1974",
+      "text": "1974",
+      "icon": "⚖️",
+      "ariaLabel": "BP issues county court proceedings but offers licence"
+    },
+    {
+      "key": "1969",
+      "text": "1969",
+      "icon": "📜",
+      "ariaLabel": "BP Pension Trust purchases the estate"
+    },
+    {
+      "key": "1965–1967",
+      "text": "1965–1967",
+      "icon": "🕯️",
+      "ariaLabel": "Frederick Buckler dies; Mary and children remain"
+    },
+    {
+      "key": "1965",
+      "text": "1965",
+      "icon": "📜",
+      "ariaLabel": "Mary Buckler refuses renewed tenancy"
+    },
+    {
+      "key": "1960s",
+      "text": "1960s",
+      "icon": "🏘️",
+      "ariaLabel": "Housing estate and school rise on Great House Farm's former fields"
+    },
+    {
+      "key": "1963",
+      "text": "1963",
+      "icon": "⚖️",
+      "ariaLabel": "Suspended committal order against Frederick Buckler"
+    },
+    {
+      "key": "1962",
+      "text": "1962",
+      "icon": "⚖️",
+      "ariaLabel": "Western Ground Rents files High Court action"
+    },
+    {
+      "key": "1959",
+      "text": "1959",
+      "icon": "👪",
+      "ariaLabel": "Mary Buckler asserts inherited ownership"
+    },
+    {
+      "key": "1955",
+      "text": "1955",
+      "icon": "⚖️",
+      "ariaLabel": "Notice to quit and Order 14 possession judgment"
+    },
+    {
+      "key": "1953",
+      "text": "1953",
+      "icon": "⚖️",
+      "ariaLabel": "Last rent payment under court pressure"
+    },
+    {
+      "key": "1938",
+      "text": "1938",
+      "icon": "📜",
+      "ariaLabel": "Reversion conveyed to Western Ground Rents"
+    },
+    {
+      "key": "1916",
+      "text": "1916",
+      "icon": "📜",
+      "ariaLabel": "Yearly tenancy granted to John Williams"
+    },
+    {
+      "key": "1897",
+      "text": "1897",
+      "icon": "📡",
+      "ariaLabel": "Marconi conducts wireless experiments with help from Great House Farm"
+    },
+    {
+      "key": "1890s",
+      "text": "1890s",
+      "icon": "💍",
+      "ariaLabel": "Williams heirs marry into the Buckler family"
+    },
+    {
+      "key": "1800s",
+      "text": "1800s",
+      "icon": "👪",
+      "ariaLabel": "Victorian sources trace the shift toward the Bucklers"
+    },
+    {
+      "key": "c. 1880",
+      "text": "c. 1880",
+      "icon": "🛡️",
+      "ariaLabel": "Victorians uncover a medieval soldier's remains beneath the farmhouse"
+    },
+    {
+      "key": "1840s",
+      "text": "1840s",
+      "icon": "🗺️",
+      "ariaLabel": "Tithe surveys list Great House Farm under Williams occupation"
+    },
+    {
+      "key": "Late 1700s",
+      "text": "Late 1700s",
+      "icon": "📜",
+      "ariaLabel": "Estate correspondence renews the family's tenure"
+    },
+    {
+      "key": "1700s",
+      "text": "1700s",
+      "icon": "👪",
+      "ariaLabel": "Eighteenth-century records confirm Williams continuity"
+    },
+    {
+      "key": "Mid-1600s",
+      "text": "Mid-1600s",
+      "icon": "📜",
+      "ariaLabel": "Estate surveys describe the seventeenth-century farmstead"
+    },
+    {
+      "key": "1600s",
+      "text": "1600s",
+      "icon": "👪",
+      "ariaLabel": "Williams stewardship anchors the family's later claims"
+    },
+    {
+      "key": "c. 1600",
+      "text": "c. 1600",
+      "icon": "📜",
+      "ariaLabel": "Williams family establishes tenancy at Great House Farm"
+    },
+    {
+      "key": "12th century",
+      "text": "12th century",
+      "icon": "⛪",
+      "ariaLabel": "Llandough hosts an early monastery and medieval grange"
+    }
+  ]
+}

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -71,6 +71,94 @@
     return limitWords(event.year, 4);
   }
 
+  function normalizeMenuEntries(menuConfig) {
+    if (!menuConfig || !Array.isArray(menuConfig.entries)) {
+      return [];
+    }
+
+    return menuConfig.entries
+      .map(entry => {
+        if (!entry) {
+          return null;
+        }
+        const rawKey = typeof entry.key === 'string' ? entry.key.trim() : '';
+        if (!rawKey) {
+          return null;
+        }
+        const normalized = rawKey.toLowerCase();
+        const text = typeof entry.text === 'string' ? entry.text.trim() : '';
+        const icon = typeof entry.icon === 'string' ? entry.icon.trim() : '';
+        const ariaLabel =
+          typeof entry.ariaLabel === 'string' ? entry.ariaLabel.trim() : '';
+
+        return {
+          key: normalized,
+          text: text || null,
+          icon: icon || null,
+          ariaLabel: ariaLabel || null,
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function applyMenuConfiguration(groups, menuConfig) {
+    if (!Array.isArray(groups) || !groups.length) {
+      return Array.isArray(groups) ? groups : [];
+    }
+
+    const normalized = normalizeMenuEntries(menuConfig);
+    if (!normalized.length) {
+      return groups;
+    }
+
+    const byKey = new Map();
+    groups.forEach(group => {
+      if (group && typeof group.key === 'string') {
+        byKey.set(group.key.toLowerCase(), group);
+      }
+    });
+
+    const remainingOrder = new Set(byKey.keys());
+    const ordered = [];
+
+    normalized.forEach(entry => {
+      const group = byKey.get(entry.key);
+      if (!group) {
+        return;
+      }
+
+      if (entry.text) {
+        group.yearLabel = entry.text;
+      }
+      if (entry.icon) {
+        group.icon = entry.icon;
+      }
+      if (entry.ariaLabel) {
+        group.label = entry.ariaLabel;
+      } else if (entry.text) {
+        group.label = entry.text;
+      }
+
+      ordered.push(group);
+      remainingOrder.delete(entry.key);
+    });
+
+    if (remainingOrder.size) {
+      groups.forEach(group => {
+        if (!group || typeof group.key !== 'string') {
+          return;
+        }
+        const key = group.key.toLowerCase();
+        if (remainingOrder.has(key)) {
+          ordered.push(group);
+          remainingOrder.delete(key);
+        }
+      });
+    }
+
+    return ordered;
+  }
+
   function buildCenturyScale(container, bounds) {
     if (!container) {
       return;
@@ -82,7 +170,7 @@
     ticks.className = 'timeline-century__ticks';
     scale.appendChild(ticks);
 
-    const { startYear, endYear, span } = bounds;
+    const { startYear, endYear } = bounds;
     for (let year = startYear; year <= endYear; year += 1) {
       const tick = document.createElement('div');
       tick.className = 'timeline-century__tick timeline-century__tick--year';
@@ -95,6 +183,19 @@
       if (year % 100 === 0) {
         tick.classList.add('timeline-century__tick--century');
       }
+      ticks.appendChild(tick);
+    }
+
+    container.appendChild(scale);
+    return scale;
+  }
+
+  function buildYearGroups(data) {
+    if (!data || !Array.isArray(data.centuries)) {
+      return [];
+    }
+
+    const groups = new Map();
 
     data.centuries.forEach((century, centuryIndex) => {
       const events = Array.isArray(century?.events) ? century.events : [];
@@ -343,7 +444,8 @@
       button.dataset.yearKey = group.key;
       button.setAttribute('role', 'option');
       button.setAttribute('aria-selected', 'false');
-      button.setAttribute('aria-label', group.label);
+      const ariaLabel = group.label || group.yearLabel || group.key || `Year ${index + 1}`;
+      button.setAttribute('aria-label', ariaLabel);
       button.tabIndex = index === 0 ? 0 : -1;
 
       const icon = document.createElement('span');
@@ -353,7 +455,8 @@
 
       const label = document.createElement('span');
       label.className = 'xmb-year__label';
-      label.textContent = limitWords(group.yearLabel, 2) || `Year ${index + 1}`;
+      const displayLabel = group.yearLabel || group.label || `Year ${index + 1}`;
+      label.textContent = limitWords(displayLabel, 3) || `Year ${index + 1}`;
       button.appendChild(label);
 
       button.addEventListener('click', () => {
@@ -454,15 +557,25 @@
   document.addEventListener('keydown', handleKeydown);
   window.addEventListener('resize', handleResize);
 
-  fetch('data/timeline.json')
-    .then(response => {
+  function fetchJson(url) {
+    return fetch(url).then(response => {
       if (!response.ok) {
-        throw new Error('Failed to load timeline data');
+        throw new Error(`Failed to load ${url}`);
       }
       return response.json();
-    })
-    .then(data => {
-      yearGroups = buildYearGroups(data);
+    });
+  }
+
+  Promise.all([
+    fetchJson('data/timeline.json'),
+    fetchJson('data/menu.json').catch(error => {
+      console.warn('Menu configuration could not be loaded:', error);
+      return null;
+    }),
+  ])
+    .then(([timelineData, menuConfig]) => {
+      const groups = buildYearGroups(timelineData) || [];
+      yearGroups = applyMenuConfiguration(groups, menuConfig);
       if (!yearGroups.length) {
         showLoading('No timeline data available.');
         return;


### PR DESCRIPTION
## Summary
- add a `data/menu.json` file that lists the icon, label, and aria text for each timeline navigation entry
- load the optional menu configuration when bootstrapping the timeline and apply the configured ordering, icons, and labels to the rendered buttons

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68f1451684348320950896f1c9362d23