### PR TITLE
Fix timeline rendering for static deployment

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Great House Farm Timeline</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2064%2064%22%3E%3Crect%20width%3D%2264%22%20height%3D%2264%22%20rx%3D%2212%22%20fill%3D%22%232563eb%22/%3E%3Ctext%20x%3D%2232%22%20y%3D%2242%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%22%20font-size%3D%2232%22%20fill%3D%22%23ffffff%22%3EGH%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
@@ -418,7 +419,7 @@
         padding-left: 12px;
         padding-right: 12px;
       }
-      
+
       .timeline-entry {
         column-gap: 14px;
       }
@@ -436,6 +437,288 @@
 
       .xmb-year__label {
         font-size: clamp(0.95rem, 4vw, 1.2rem);
+      }
+    }
+
+    /* Layout overrides to support the static deployment */
+    html,
+    body {
+      overflow: auto;
+    }
+
+    .xmb-stage {
+      overflow: visible;
+      display: flex;
+      justify-content: center;
+      padding: clamp(48px, 8vw, 96px) clamp(24px, 6vw, 72px)
+        clamp(72px, 10vw, 120px);
+    }
+
+    .xmb-vertical {
+      position: relative;
+      left: auto;
+      right: auto;
+      top: auto;
+      bottom: auto;
+      width: 100%;
+      max-width: 1120px;
+    }
+
+    .xmb-vertical__viewport {
+      width: 100%;
+      max-width: none;
+      height: auto;
+      overflow: visible;
+    }
+
+    .xmb-vertical__list {
+      position: relative;
+      min-height: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+    }
+
+    .xmb-entry {
+      position: relative;
+      min-width: 100%;
+      max-width: none;
+      height: auto;
+      transform: none !important;
+      background: var(--surface);
+      border-radius: 24px;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--shadow-soft);
+      padding: clamp(1rem, 2.4vw, 1.6rem);
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: clamp(0.9rem, 2vw, 1.4rem);
+      transition: box-shadow 0.3s ease, background 0.3s ease;
+    }
+
+    .xmb-entry[data-side='buckler'] {
+      background: var(--buckler-surface);
+      border-left: 6px solid var(--buckler-border);
+    }
+
+    .xmb-entry[data-side='bp'] {
+      background: var(--bp-surface);
+      border-left: 6px solid var(--bp-border);
+    }
+
+    .xmb-entry[data-side='shared'],
+    .xmb-entry[data-side='both'],
+    .xmb-entry[data-side='either'] {
+      background: var(--shared-surface);
+      border-left: 6px solid var(--shared-border);
+    }
+
+    .xmb-entry.is-active {
+      box-shadow: var(--shadow-strong);
+    }
+
+    .xmb-entry__icon {
+      width: clamp(3rem, 6vw, 3.75rem);
+      height: clamp(3rem, 6vw, 3.75rem);
+      border-radius: 999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: clamp(1.4rem, 3vw, 2rem);
+      background: rgba(15, 23, 42, 0.12);
+      box-shadow: none;
+    }
+
+    .xmb-entry__copy {
+      text-transform: none;
+      letter-spacing: 0;
+      gap: clamp(0.35rem, 1.2vw, 0.75rem);
+    }
+
+    .xmb-entry__title {
+      font-size: clamp(1.05rem, 2.4vw, 1.4rem);
+      letter-spacing: 0;
+    }
+
+    .xmb-entry__subtitle {
+      font-size: clamp(0.85rem, 1.8vw, 1rem);
+      color: var(--text-muted);
+      letter-spacing: 0;
+    }
+
+    .xmb-entry__body {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(0.65rem, 1.5vw, 0.9rem);
+      color: var(--text-soft);
+      font-size: clamp(0.85rem, 1.8vw, 1rem);
+      line-height: 1.6;
+    }
+
+    .xmb-entry__body ul {
+      margin: 0;
+      padding-left: 1.1em;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .xmb-entry__body li strong {
+      display: block;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .xmb-entry details {
+      background: rgba(15, 23, 42, 0.04);
+      border-radius: 16px;
+      padding: clamp(0.65rem, 1.4vw, 0.9rem)
+        clamp(0.75rem, 1.8vw, 1.1rem);
+    }
+
+    .xmb-entry summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--heading-color);
+      list-style: none;
+    }
+
+    .xmb-entry summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .xmb-entry summary::before {
+      content: '▸';
+      display: inline-block;
+      margin-right: 0.5rem;
+      transition: transform 0.2s ease;
+    }
+
+    .xmb-entry details[open] summary::before {
+      transform: rotate(90deg);
+    }
+
+    .xmb-horizontal {
+      position: sticky;
+      top: 0;
+      padding: clamp(1.1rem, 3vw, 1.8rem) clamp(1.5rem, 5vw, 5rem);
+      margin: 0 auto;
+      backdrop-filter: blur(12px);
+      box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.08);
+      z-index: 10;
+    }
+
+    .xmb-horizontal__viewport {
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding: 0;
+      scrollbar-width: thin;
+    }
+
+    .xmb-horizontal__track {
+      display: inline-flex;
+      gap: clamp(0.75rem, 1.5vw, 1.1rem);
+      padding-bottom: 0.25rem;
+    }
+
+    .xmb-year {
+      min-width: auto;
+      flex: none;
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      border: 1px solid rgba(59, 130, 246, 0.25);
+      gap: 0.6rem;
+      transform: none;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      transition: background 0.3s ease, color 0.3s ease,
+        border-color 0.3s ease;
+    }
+
+    .xmb-year__icon {
+      width: 2.2rem;
+      height: 2.2rem;
+      font-size: 1.1rem;
+      background: rgba(59, 130, 246, 0.18);
+      box-shadow: none;
+    }
+
+    .xmb-year__label {
+      white-space: nowrap;
+      font-size: 0.95rem;
+    }
+
+    .xmb-year__subtitle {
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      opacity: 0.75;
+    }
+
+    .xmb-year.is-active {
+      background: var(--accent-primary);
+      border-color: var(--accent-primary);
+      color: #ffffff;
+    }
+
+    .xmb-year:focus-visible {
+      outline-offset: 3px;
+    }
+
+    .xmb-horizontal__fade {
+      display: none;
+    }
+
+    .xmb-loading {
+      top: 1rem;
+      right: 1rem;
+    }
+
+    .xmb-century-header {
+      background: var(--surface-muted);
+      border-left: 6px solid var(--accent-primary);
+      border-radius: 20px;
+      padding: clamp(1rem, 2vw, 1.4rem) clamp(1.2rem, 3vw, 1.8rem);
+      box-shadow: var(--shadow-soft);
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+
+    .xmb-century-header__title {
+      margin: 0;
+      font-size: clamp(1.25rem, 3vw, 1.6rem);
+      font-weight: 700;
+      color: var(--heading-color);
+    }
+
+    .xmb-century-header__range {
+      margin: 0;
+      font-size: clamp(0.95rem, 2vw, 1.15rem);
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    @media (max-width: 768px) {
+      .xmb-stage {
+        padding: clamp(36px, 10vw, 56px) clamp(18px, 5vw, 32px)
+          clamp(80px, 12vw, 120px);
+      }
+
+      .xmb-horizontal {
+        padding-left: clamp(1rem, 6vw, 2rem);
+        padding-right: clamp(1rem, 6vw, 2rem);
+      }
+
+      .xmb-entry {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .xmb-entry__icon {
+        justify-self: flex-start;
       }
     }
   </style>

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -1,137 +1,566 @@
 (function () {
-  const rootElement = document.documentElement;
-  const yearTrack = document.getElementById('timeline-year-track');
-  const yearViewport = document.getElementById('year-bar-viewport');
-  const entryViewport = document.getElementById('timeline-entry-viewport');
-  const entryList = document.getElementById('timeline-year-entries');
-  const loadingBanner = document.getElementById('timeline-loading');
-
-  if (!yearTrack || !entryViewport || !entryList) {
-    return;
-  }
-
-  const LEADING_PLACEHOLDER_COUNT = 2;
-
-  let yearGroups = [];
-  let yearButtons = [];
-  let entryItems = [];
-  let activeYearIndex = 0;
-  let activeEntryIndex = 0;
-  let suppressFocusSync = false;
-  let focusColumnOffset = 0;
-  const layoutMetrics = {
-    historyHeight: 0,
-    horizontalHeight: 0,
-    spacerHeight: 0,
-    entryHeight: 0,
-    entryGap: 0,
-  };
-
-  function readCssNumber(variableName, fallback = 0) {
-    const raw = getComputedStyle(rootElement).getPropertyValue(variableName);
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-
-  function refreshLayoutMetrics() {
-    layoutMetrics.historyHeight = readCssNumber('--row-history-height', 96);
-    layoutMetrics.horizontalHeight = readCssNumber('--horizontal-band-height', layoutMetrics.historyHeight);
-    layoutMetrics.spacerHeight = readCssNumber('--row-spacer-height', 24);
-    layoutMetrics.entryHeight = readCssNumber('--entry-row-height', layoutMetrics.historyHeight);
-    layoutMetrics.entryGap = readCssNumber('--entry-gap', 16);
-  }
-
-  function limitWords(value, maxWords) {
-    if (!value) {
-      return '';
+  function onReady(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
     }
-    const words = String(value).trim().split(/\s+/);
-    return words.slice(0, Math.max(1, maxWords)).join(' ');
   }
 
-  function getYearSubtitle(group) {
-    if (!group || !group.events.length) {
-      return '';
-    }
-    const primaryEvent = group.events[0].event;
-    const subtitleSource = primaryEvent.iconLabel || primaryEvent.title || primaryEvent.year || '';
-    return limitWords(subtitleSource, 4);
-  }
+  var yearTrack;
+  var yearViewport;
+  var entryList;
+  var loadingBanner;
+  var yearGroups = [];
+  var yearButtons = [];
+  var entryItems = [];
+  var activeYearIndex = -1;
+  var activeEntryIndex = -1;
 
-  function getEventSubtitle(event) {
-    if (!event) {
-      return '';
-    }
-    if (event.summary) {
-      return limitWords(event.summary, 4);
-    }
-    if (event.title) {
-      return limitWords(event.title, 4);
-    }
-    return limitWords(event.year, 4);
-  }
+  onReady(initialize);
 
-    const groups = new Map();
+  function initialize() {
+    yearTrack = document.getElementById('timeline-year-track');
+    yearViewport = document.getElementById('year-bar-viewport');
+    entryList = document.getElementById('timeline-year-entries');
+    loadingBanner = document.getElementById('timeline-loading');
 
-    data.centuries.forEach((century, centuryIndex) => {
-      const events = Array.isArray(century?.events) ? century.events : [];
-      events.forEach((event, eventIndex) => {
-        if (!event || !event.id) {
+    if (!yearTrack || !entryList) {
+      return;
+    }
+
+    if (yearTrack.getAttribute('role') !== 'listbox') {
+      yearTrack.setAttribute('role', 'listbox');
+    }
+
+    showLoading('Loading timeline…');
+
+    fetch('data/timeline.json')
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load timeline data');
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        yearGroups = buildCenturyGroups(data);
+        if (!yearGroups.length) {
+          showLoading('Timeline data is not available.');
           return;
         }
-        const label = (typeof event.year === 'string' && event.year.trim()) || 'Undated';
-        const key = label.toLowerCase();
-        if (!groups.has(key)) {
-          groups.set(key, {
-            label,
-            key,
-            events: [],
-            sortValue: Number.isFinite(event.yearValue) ? event.yearValue : null,
-          });
-        }
-        const group = groups.get(key);
-        const yearValue = Number.isFinite(event.yearValue) ? event.yearValue : null;
-        if (Number.isFinite(yearValue)) {
-          if (!Number.isFinite(group.sortValue) || yearValue < group.sortValue) {
-            group.sortValue = yearValue;
-          }
-        }
-        group.events.push({
-          event,
-          century,
-          centuryIndex,
-          eventIndex,
-        });
+        renderYearButtons(yearGroups);
+        setActiveYear(0, true);
+        hideLoading();
+      })
+      .catch(function (error) {
+        console.error(error);
+        showLoading('We could not load the timeline data. Please refresh the page.');
       });
-    });
 
-    const ordered = Array.from(groups.values());
-    ordered.sort((a, b) => {
-      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.NEGATIVE_INFINITY;
-      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.NEGATIVE_INFINITY;
-      if (aValue !== bValue) {
-        return bValue - aValue;
-      }
-      return b.label.localeCompare(a.label, undefined, { numeric: true });
-    });
+    document.addEventListener('keydown', handleKeyNavigation);
+  }
 
-    ordered.forEach((group, index) => {
-      group.events.sort((a, b) => {
-        const aValue = Number.isFinite(a.event.yearValue) ? a.event.yearValue : Number.NEGATIVE_INFINITY;
-        const bValue = Number.isFinite(b.event.yearValue) ? b.event.yearValue : Number.NEGATIVE_INFINITY;
+  function buildCenturyGroups(data) {
+    var result = [];
+    if (!data || !data.centuries || !data.centuries.length) {
+      return result;
+    }
+
+    for (var i = 0; i < data.centuries.length; i += 1) {
+      var century = data.centuries[i] || {};
+      var events = Array.isArray(century.events)
+        ? century.events.slice()
+        : [];
+
+      events.sort(function (a, b) {
+        var aValue = typeof a.yearValue === 'number' ? a.yearValue : Number.POSITIVE_INFINITY;
+        var bValue = typeof b.yearValue === 'number' ? b.yearValue : Number.POSITIVE_INFINITY;
         if (aValue !== bValue) {
-          return bValue - aValue;
+          return aValue - bValue;
         }
-        return a.eventIndex - b.eventIndex;
+        var aLabel = (a.year || '').toString();
+        var bLabel = (b.year || '').toString();
+        return aLabel.localeCompare(bLabel, undefined, { numeric: true });
       });
-      const primaryEventWithIcon = group.events.find(entry => entry.event.icon);
-      const primaryEvent = group.events[0]?.event;
-      group.icon = primaryEventWithIcon?.event?.icon || '🕰️';
-      group.yearLabel = limitWords(primaryEvent?.year || group.label, 2) || `Year ${index + 1}`;
-      group.subtitle = getYearSubtitle(group);
+
+      var groupIcon = '🕰️';
+      for (var j = 0; j < events.length; j += 1) {
+        if (events[j] && events[j].icon) {
+          groupIcon = events[j].icon;
+          break;
+        }
+      }
+
+      var rangeLabel = typeof century.range === 'string' && century.range.trim()
+        ? century.range.trim()
+        : '';
+      var titleLabel = typeof century.title === 'string' && century.title.trim()
+        ? century.title.trim()
+        : '';
+
+      var sortValue = typeof century.startYear === 'number'
+        ? century.startYear
+        : null;
+      if (sortValue === null && events.length) {
+        var firstEvent = events[0];
+        if (firstEvent && typeof firstEvent.yearValue === 'number') {
+          sortValue = firstEvent.yearValue;
+        }
+      }
+      if (sortValue === null) {
+        sortValue = Number.POSITIVE_INFINITY;
+      }
+
+      result.push({
+        id: century.id || 'century-' + i,
+        icon: groupIcon,
+        label: rangeLabel || titleLabel || 'Century ' + (i + 1),
+        subtitle: rangeLabel && titleLabel && rangeLabel !== titleLabel ? titleLabel : '',
+        range: rangeLabel,
+        title: titleLabel,
+        events: events,
+        sortValue: sortValue,
+      });
+    }
+
+    result.sort(function (a, b) {
+      if (a.sortValue !== b.sortValue) {
+        return a.sortValue - b.sortValue;
+      }
+      return a.label.localeCompare(b.label, undefined, { numeric: true });
     });
 
-    return ordered;
+    return result;
+  }
+
+  function renderYearButtons(groups) {
+    yearTrack.innerHTML = '';
+    yearButtons = [];
+
+    for (var i = 0; i < groups.length; i += 1) {
+      var group = groups[i];
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'xmb-year';
+      button.dataset.yearKey = group.id;
+      button.setAttribute('role', 'option');
+      button.setAttribute('aria-selected', 'false');
+      button.title = group.subtitle ? group.label + ' · ' + group.subtitle : group.label;
+
+      var icon = document.createElement('span');
+      icon.className = 'xmb-year__icon';
+      icon.textContent = group.icon;
+      button.appendChild(icon);
+
+      var label = document.createElement('span');
+      label.className = 'xmb-year__label';
+      label.textContent = group.label;
+      button.appendChild(label);
+
+      if (group.subtitle) {
+        var subtitle = document.createElement('span');
+        subtitle.className = 'xmb-year__subtitle';
+        subtitle.textContent = group.subtitle;
+        button.appendChild(subtitle);
+      }
+
+      (function (index) {
+        button.addEventListener('click', function () {
+          setActiveYear(index, false);
+        });
+        button.addEventListener('keydown', function (event) {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setActiveYear(index, true);
+          }
+        });
+      })(i);
+
+      yearTrack.appendChild(button);
+      yearButtons.push(button);
+    }
+  }
+
+  function setActiveYear(index, focusYear) {
+    if (!yearGroups.length) {
+      return;
+    }
+
+    var clamped = Math.max(0, Math.min(yearGroups.length - 1, index));
+    if (clamped === activeYearIndex && !focusYear) {
+      return;
+    }
+
+    activeYearIndex = clamped;
+    for (var i = 0; i < yearButtons.length; i += 1) {
+      var isActive = i === clamped;
+      var button = yearButtons[i];
+      if (!button) {
+        continue;
+      }
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.tabIndex = isActive ? 0 : -1;
+      if (isActive && focusYear) {
+        button.focus({ preventScroll: true });
+      }
+    }
+
+    scrollYearIntoView(clamped);
+    renderEntryList(yearGroups[clamped]);
+  }
+
+  function renderEntryList(group) {
+    entryList.innerHTML = '';
+    entryItems = [];
+    activeEntryIndex = -1;
+
+    if (!group) {
+      return;
+    }
+
+    if (group.title || group.range) {
+      entryList.appendChild(createCenturyHeader(group));
+    }
+
+    if (!group.events.length) {
+      var empty = document.createElement('p');
+      empty.textContent = 'No events recorded for this period.';
+      entryList.appendChild(empty);
+      return;
+    }
+
+    for (var i = 0; i < group.events.length; i += 1) {
+      var event = group.events[i];
+      if (!event) {
+        continue;
+      }
+      var entry = createEventEntry(event, i);
+      entryList.appendChild(entry);
+      entryItems.push(entry);
+    }
+
+    if (entryItems.length) {
+      setActiveEntry(0, false);
+    }
+  }
+
+  function createCenturyHeader(group) {
+    var header = document.createElement('header');
+    header.className = 'xmb-century-header';
+
+    if (group.title) {
+      var title = document.createElement('h2');
+      title.className = 'xmb-century-header__title';
+      title.textContent = group.title;
+      header.appendChild(title);
+    }
+
+    if (group.range) {
+      var range = document.createElement('p');
+      range.className = 'xmb-century-header__range';
+      range.textContent = group.range;
+      header.appendChild(range);
+    }
+
+    return header;
+  }
+
+  function createEventEntry(event, index) {
+    var entry = document.createElement('article');
+    entry.className = 'xmb-entry';
+    entry.setAttribute('role', 'listitem');
+    entry.tabIndex = 0;
+
+    var side = typeof event.side === 'string' ? event.side.toLowerCase() : '';
+    if (side === 'both') {
+      side = 'shared';
+    }
+    if (!side) {
+      side = 'shared';
+    }
+    entry.dataset.side = side;
+
+    var icon = document.createElement('span');
+    icon.className = 'xmb-entry__icon';
+    icon.textContent = event.icon || selectFallbackIcon(side);
+    entry.appendChild(icon);
+
+    var copy = document.createElement('div');
+    copy.className = 'xmb-entry__copy';
+    entry.appendChild(copy);
+
+    var title = document.createElement('h3');
+    title.className = 'xmb-entry__title';
+    title.textContent = event.title || event.year || 'Timeline entry';
+    copy.appendChild(title);
+
+    var subtitleText = buildEntrySubtitle(event);
+    if (subtitleText) {
+      var subtitle = document.createElement('p');
+      subtitle.className = 'xmb-entry__subtitle';
+      subtitle.textContent = subtitleText;
+      copy.appendChild(subtitle);
+    }
+
+    var body = document.createElement('div');
+    body.className = 'xmb-entry__body';
+
+    appendParagraph(body, event.summary);
+    appendListSection(body, 'Context', event.context);
+    appendEvidenceSection(body, event.evidence);
+
+    if (body.childNodes.length) {
+      copy.appendChild(body);
+    }
+
+    entry.addEventListener('click', function () {
+      setActiveEntry(index, false);
+    });
+
+    entry.addEventListener('keydown', function (eventObject) {
+      if (eventObject.key === 'Enter' || eventObject.key === ' ') {
+        eventObject.preventDefault();
+        setActiveEntry(index, true);
+      }
+    });
+
+    return entry;
+  }
+
+  function buildEntrySubtitle(event) {
+    var pieces = [];
+    if (event.year) {
+      pieces.push(String(event.year));
+    }
+    if (event.summary && pieces.join(' ').length < 120) {
+      pieces.push(event.summary);
+    }
+    return pieces.join(' • ');
+  }
+
+  function appendParagraph(container, text) {
+    if (!text) {
+      return;
+    }
+    var paragraph = document.createElement('p');
+    paragraph.textContent = text;
+    container.appendChild(paragraph);
+  }
+
+  function appendListSection(container, heading, items) {
+    if (!Array.isArray(items) || !items.length) {
+      return;
+    }
+    var list = document.createElement('ul');
+    for (var i = 0; i < items.length; i += 1) {
+      if (!items[i]) {
+        continue;
+      }
+      var item = document.createElement('li');
+      item.textContent = items[i];
+      list.appendChild(item);
+    }
+    if (!list.childNodes.length) {
+      return;
+    }
+    var details = document.createElement('details');
+    var summary = document.createElement('summary');
+    summary.textContent = heading;
+    details.appendChild(summary);
+    details.appendChild(list);
+    container.appendChild(details);
+  }
+
+  function appendEvidenceSection(container, evidenceItems) {
+    if (!Array.isArray(evidenceItems) || !evidenceItems.length) {
+      return;
+    }
+
+    var list = document.createElement('ul');
+
+    for (var i = 0; i < evidenceItems.length; i += 1) {
+      var evidence = evidenceItems[i];
+      if (!evidence) {
+        continue;
+      }
+      var listItem = document.createElement('li');
+
+      if (evidence.title) {
+        var title = document.createElement('strong');
+        title.textContent = evidence.title;
+        listItem.appendChild(title);
+      }
+
+      if (evidence.description) {
+        var description = document.createElement('p');
+        description.textContent = evidence.description;
+        listItem.appendChild(description);
+      }
+
+      if (evidence.source && evidence.source.url) {
+        var sourceLink = document.createElement('a');
+        sourceLink.href = evidence.source.url;
+        sourceLink.target = '_blank';
+        sourceLink.rel = 'noopener noreferrer';
+        sourceLink.textContent = evidence.source.name || evidence.source.url;
+        listItem.appendChild(sourceLink);
+      }
+
+      if (Array.isArray(evidence.content) && evidence.content.length) {
+        var subList = document.createElement('ul');
+        for (var j = 0; j < evidence.content.length; j += 1) {
+          if (!evidence.content[j]) {
+            continue;
+          }
+          var bullet = document.createElement('li');
+          bullet.textContent = evidence.content[j];
+          subList.appendChild(bullet);
+        }
+        if (subList.childNodes.length) {
+          listItem.appendChild(subList);
+        }
+      }
+
+      list.appendChild(listItem);
+    }
+
+    if (list.childNodes.length) {
+      var details = document.createElement('details');
+      var summary = document.createElement('summary');
+      summary.textContent = 'Evidence';
+      details.appendChild(summary);
+      details.appendChild(list);
+      container.appendChild(details);
+    }
+  }
+
+  function selectFallbackIcon(side) {
+    if (side === 'buckler') {
+      return '🌿';
+    }
+    if (side === 'bp') {
+      return '🏢';
+    }
+    return '📜';
+  }
+
+  function setActiveEntry(index, focusEntry) {
+    if (!entryItems.length) {
+      return;
+    }
+
+    var clamped = Math.max(0, Math.min(entryItems.length - 1, index));
+    if (clamped === activeEntryIndex && !focusEntry) {
+      return;
+    }
+
+    activeEntryIndex = clamped;
+
+    for (var i = 0; i < entryItems.length; i += 1) {
+      var entry = entryItems[i];
+      if (!entry) {
+        continue;
+      }
+      var isActive = i === clamped;
+      entry.classList.toggle('is-active', isActive);
+      if (isActive) {
+        entry.setAttribute('aria-current', 'true');
+        var details = entry.querySelectorAll('details');
+        for (var j = 0; j < details.length; j += 1) {
+          details[j].open = true;
+        }
+        ensureEntryVisible(entry);
+        if (focusEntry) {
+          entry.focus({ preventScroll: true });
+        }
+      } else {
+        entry.removeAttribute('aria-current');
+        var allDetails = entry.querySelectorAll('details');
+        for (var k = 0; k < allDetails.length; k += 1) {
+          allDetails[k].open = false;
+        }
+      }
+    }
+  }
+
+  function ensureEntryVisible(entry) {
+    if (!entry) {
+      return;
+    }
+    var viewport = entryList.parentElement || entryList;
+    if (!viewport || typeof viewport.getBoundingClientRect !== 'function') {
+      return;
+    }
+    var viewportRect = viewport.getBoundingClientRect();
+    var entryRect = entry.getBoundingClientRect();
+    if (entryRect.top < viewportRect.top + 20 || entryRect.bottom > viewportRect.bottom - 20) {
+      if (typeof entry.scrollIntoView === 'function') {
+        entry.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+  }
+
+  function scrollYearIntoView(index) {
+    if (!yearViewport || !yearButtons.length) {
+      return;
+    }
+    var button = yearButtons[index];
+    if (!button) {
+      return;
+    }
+    var target = button.offsetLeft - Math.max(0, (yearViewport.clientWidth - button.offsetWidth) / 2);
+    if (target < 0) {
+      target = 0;
+    }
+    if (typeof yearViewport.scrollTo === 'function') {
+      yearViewport.scrollTo({ left: target, behavior: 'smooth' });
+    } else {
+      yearViewport.scrollLeft = target;
+    }
+  }
+
+  function handleKeyNavigation(event) {
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+    if (!yearGroups.length) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowRight':
+        event.preventDefault();
+        setActiveYear(activeYearIndex + 1, true);
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        setActiveYear(activeYearIndex - 1, true);
+        break;
+      case 'ArrowDown':
+        if (entryItems.length) {
+          event.preventDefault();
+          setActiveEntry(activeEntryIndex + 1, true);
+        }
+        break;
+      case 'ArrowUp':
+        if (entryItems.length) {
+          event.preventDefault();
+          setActiveEntry(activeEntryIndex - 1, true);
+        }
+        break;
+      default:
+    }
+  }
+
+  function showLoading(message) {
+    if (!loadingBanner) {
+      return;
+    }
+    if (message) {
+      loadingBanner.textContent = message;
+    }
+    loadingBanner.classList.remove('is-hidden');
   }
 
   function hideLoading() {
@@ -139,317 +568,4 @@
       loadingBanner.classList.add('is-hidden');
     }
   }
-
-  function buildEvent(event, century, bounds) {
-    const position = choosePosition(event);
-    const entry = document.createElement('div');
-    entry.className = 'timeline-entry';
-    entry.dataset.position = position;
-    entry.dataset.eventId = event.id;
-
-    const eventYear = getEventYearValue(event, bounds);
-    if (Number.isFinite(eventYear)) {
-      entry.dataset.yearValue = String(eventYear);
-    }
-  }
-
-  function clearEntryList() {
-    entryList.innerHTML = '';
-    entryList.style.minHeight = '';
-    entryItems = [];
-    activeEntryIndex = 0;
-  }
-
-  function updateFocusOffset() {
-    const firstButton = yearButtons[0];
-    focusColumnOffset = firstButton ? firstButton.offsetLeft : 0;
-  }
-
-  function alignYearTrack() {
-    const activeButton = yearButtons[activeYearIndex];
-    if (!activeButton) {
-      yearTrack.style.transform = 'translateX(0)';
-      return;
-    }
-
-    updateFocusOffset();
-
-    const offset = activeButton.offsetLeft;
-    const viewportWidth = yearViewport?.clientWidth || 0;
-    const trackWidth = yearTrack.scrollWidth;
-    const desired = focusColumnOffset - offset;
-    const lastButton = yearButtons[yearButtons.length - 1];
-    let minTranslate = Math.min(0, viewportWidth - trackWidth);
-    if (lastButton) {
-      const lastRight = lastButton.offsetLeft + lastButton.offsetWidth;
-      const boundary = viewportWidth - lastRight;
-      minTranslate = Math.min(minTranslate, boundary);
-      minTranslate = Math.min(minTranslate, focusColumnOffset - lastButton.offsetLeft);
-    }
-    const maxTranslate = 0;
-    const clamped = Math.max(minTranslate, Math.min(maxTranslate, desired));
-    yearTrack.style.transform = `translateX(${clamped}px)`;
-  }
-
-  function applyEntryPositions() {
-    if (!entryItems.length) {
-      entryList.style.minHeight = '';
-      return;
-    }
-
-    refreshLayoutMetrics();
-
-    const baseTop = layoutMetrics.historyHeight * 2 + layoutMetrics.horizontalHeight + layoutMetrics.spacerHeight;
-    const step = layoutMetrics.entryHeight + layoutMetrics.entryGap;
-    const minFutureItems = 2;
-
-  const rowLayout = {
-    fallbackRowHeight: 184,
-    padding: 112,
-  };
-
-  let layoutFrame = null;
-
-  function renderEntryList(group) {
-    clearEntryList();
-    if (!group || !group.events.length) {
-      return;
-    }
-    const scaleElement = entries.querySelector('.timeline-century__scale');
-    const axisRect = scaleElement ? scaleElement.getBoundingClientRect() : null;
-    const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-    entryNodes.forEach(entry => {
-      const bubble = entry.querySelector('.timeline-bubble');
-      if (!bubble) {
-        return;
-      }
-      const bubbleRect = bubble.getBoundingClientRect();
-      const targetNode = entry.querySelector('.timeline-year .timeline-node');
-      const targetRect = targetNode ? targetNode.getBoundingClientRect() : axisRect;
-      if (!targetRect) {
-        return;
-      }
-
-  function applyRowLayout() {
-    const sections = Array.from(timelineContainer.querySelectorAll('.timeline-century'));
-
-    sections.forEach(section => {
-      if (section.classList.contains('timeline-century--collapsed')) {
-        return;
-      }
-
-      const entries = section.querySelector('.timeline-century__entries');
-      if (!entries || entries.hidden) {
-        return;
-      }
-
-      const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-      entryNodes.forEach((entry, index) => {
-        entry.style.setProperty('--entry-row-index', index);
-      });
-
-      const computed = window.getComputedStyle(entries);
-      const baseMinHeight = parseFloat(computed.minHeight) || 0;
-      const rowHeightValue = parseFloat(computed.getPropertyValue('--timeline-row-height')) || rowLayout.fallbackRowHeight;
-      const requiredHeight = Math.max(baseMinHeight, entryNodes.length * rowHeightValue + rowLayout.padding);
-      if (requiredHeight > 0) {
-        entries.style.minHeight = `${Math.ceil(requiredHeight)}px`;
-      }
-    });
-
-    requestAnimationFrame(() => {
-      sections.forEach(section => {
-        updateConnectorLengths(section);
-      });
-    });
-
-  function scheduleLayout() {
-    if (layoutFrame) {
-      cancelAnimationFrame(layoutFrame);
-    }
-    layoutFrame = requestAnimationFrame(() => {
-      layoutFrame = null;
-      applyRowLayout();
-    });
-  }
-
-  function setActiveYear(index, { focusYear = false } = {}) {
-    if (!yearGroups.length) {
-      return;
-    }
-    const clamped = Math.max(0, Math.min(yearGroups.length - 1, index));
-    if (clamped === activeYearIndex && !focusYear) {
-      return;
-    }
-    activeYearIndex = clamped;
-    const group = yearGroups[activeYearIndex];
-
-    yearButtons.forEach((button, buttonIndex) => {
-      const isActive = buttonIndex === activeYearIndex;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
-      button.tabIndex = isActive ? 0 : -1;
-      if (isActive && focusYear && !suppressFocusSync) {
-        requestAnimationFrame(() => {
-          button.focus({ preventScroll: true });
-        });
-      }
-    });
-
-    alignYearTrack();
-    renderEntryList(group);
-  }
-
-  function renderYearButtons(groups) {
-    yearTrack.innerHTML = '';
-
-    for (let i = 0; i < LEADING_PLACEHOLDER_COUNT; i += 1) {
-      const spacer = document.createElement('div');
-      spacer.className = 'xmb-year-placeholder';
-      spacer.setAttribute('aria-hidden', 'true');
-      yearTrack.appendChild(spacer);
-    }
-
-    yearButtons = groups.map((group, index) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'xmb-year';
-      button.dataset.yearKey = group.key;
-      button.setAttribute('role', 'option');
-      button.setAttribute('aria-selected', 'false');
-      button.setAttribute('aria-label', group.label);
-      button.tabIndex = index === 0 ? 0 : -1;
-
-      const icon = document.createElement('span');
-      icon.className = 'xmb-year__icon';
-      icon.textContent = group.icon;
-      button.appendChild(icon);
-
-      const label = document.createElement('span');
-      label.className = 'xmb-year__label';
-      label.textContent = limitWords(group.yearLabel, 2) || `Year ${index + 1}`;
-      button.appendChild(label);
-
-      button.addEventListener('click', () => {
-        setActiveYear(index, { focusYear: true });
-      });
-
-      button.addEventListener('focus', () => {
-        if (suppressFocusSync) {
-          return;
-        }
-        setActiveYear(index, { focusYear: false });
-      });
-
-      yearTrack.appendChild(button);
-      return button;
-    });
-
-    updateFocusOffset();
-  }
-
-  function handleKeydown(event) {
-    if (event.altKey || event.ctrlKey || event.metaKey) {
-      return;
-    }
-
-    const target = event.target;
-    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-      return;
-    }
-
-    switch (event.key) {
-      case 'ArrowRight': {
-        if (!yearGroups.length) {
-          return;
-        }
-        event.preventDefault();
-        const next = Math.min(yearGroups.length - 1, activeYearIndex + 1);
-        setActiveYear(next, { focusYear: true });
-        break;
-      }
-      case 'ArrowLeft': {
-        if (!yearGroups.length) {
-          return;
-        }
-        event.preventDefault();
-        const next = Math.max(0, activeYearIndex - 1);
-        setActiveYear(next, { focusYear: true });
-        break;
-      }
-      case 'ArrowDown': {
-        if (!entryItems.length) {
-          return;
-        }
-        event.preventDefault();
-        if (document.activeElement && yearButtons.includes(document.activeElement)) {
-          setActiveEntry(0, { focus: true });
-        } else {
-          setActiveEntry(activeEntryIndex + 1, { focus: true });
-        }
-        break;
-      }
-      case 'ArrowUp': {
-        if (!entryItems.length) {
-          return;
-        }
-        event.preventDefault();
-        if (document.activeElement && entryItems.includes(document.activeElement)) {
-          if (activeEntryIndex === 0) {
-            const activeButton = yearButtons[activeYearIndex];
-            if (activeButton) {
-              suppressFocusSync = true;
-              activeButton.focus({ preventScroll: true });
-              suppressFocusSync = false;
-            }
-          } else {
-            setActiveEntry(activeEntryIndex - 1, { focus: true });
-          }
-        } else {
-          const activeButton = yearButtons[activeYearIndex];
-          if (activeButton) {
-            suppressFocusSync = true;
-            activeButton.focus({ preventScroll: true });
-            suppressFocusSync = false;
-          }
-        }
-        break;
-      }
-      default:
-    }
-  }
-
-  function handleResize() {
-    updateFocusOffset();
-    alignYearTrack();
-    applyEntryPositions();
-  }
-
-  document.addEventListener('keydown', handleKeydown);
-  window.addEventListener('resize', handleResize);
-
-  fetch('data/timeline.json')
-    .then(response => {
-      if (!response.ok) {
-        throw new Error('Failed to load timeline data');
-      }
-      return response.json();
-    })
-    .then(data => {
-      yearGroups = buildYearGroups(data);
-      if (!yearGroups.length) {
-        showLoading('No timeline data available.');
-        return;
-      }
-      renderYearButtons(yearGroups);
-      hideLoading();
-      requestAnimationFrame(() => {
-        refreshLayoutMetrics();
-        setActiveYear(0, { focusYear: true });
-      });
-    })
-    .catch(error => {
-      console.error(error);
-      showLoading('We could not load the timeline data. Please refresh the page.');
-    });
 })();


### PR DESCRIPTION
## Summary
- replace the broken timeline bundle with a standalone script that loads and renders the data in-browser without server features
- restyle the timeline layout so entries display in a scrollable column on static hosting and add an inline favicon to satisfy the browser request

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f25dc119408320a22c173497658f52