### PR TITLE
Restore BP vs Buckler timeline dark layout

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -7,65 +7,20 @@
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
-      color-scheme: light;
-      --page-background: #f3f4f6;
-      --surface: rgba(255, 255, 255, 0.94);
-      --surface-muted: rgba(255, 255, 255, 0.82);
-      --surface-border: rgba(59, 130, 246, 0.16);
-      --heading-color: #0f172a;
-      --text-primary: #1f2937;
-      --text-muted: rgba(17, 24, 39, 0.75);
-      --text-soft: rgba(17, 24, 39, 0.6);
-      --accent-primary: #2563eb;
-      --accent-primary-strong: #1e3a8a;
-      --accent-muted: rgba(59, 130, 246, 0.18);
-      --buckler-surface: linear-gradient(135deg, #d1fae5, #ecfdf5);
-      --buckler-border: #10b981;
-      --bp-surface: linear-gradient(135deg, #fee2e2, #fff1f2);
-      --bp-border: #ef4444;
-      --shared-surface: linear-gradient(135deg, #e0e7ff, #eef2ff);
-      --shared-border: #4338ca;
-      --shadow-soft: 0 22px 36px -24px rgba(15, 23, 42, 0.55);
-      --shadow-strong: 0 30px 52px -32px rgba(15, 23, 42, 0.65);
-      --modal-backdrop: rgba(15, 23, 42, 0.55);
-      --axis-column-width: 150px;
-      --entry-gap: 32px;
-      --bubble-size: 60px;
-      --year-scale: 7px;
-      --timeline-row-height: 184px;
-    }
-
-    body[data-theme='dark'] {
       color-scheme: dark;
       --page-background: #000000;
       --text-primary: #f8fafc;
       --text-muted: rgba(226, 232, 240, 0.6);
       --accent: #38bdf8;
-      --row-history-height: clamp(92px, 15vh, 132px);
-      --row-spacer-height: clamp(18px, 4vh, 28px);
-      --entry-row-height: clamp(92px, 16vh, 138px);
-      --entry-gap: clamp(12px, 3vh, 20px);
-      --horizontal-band-height: var(--row-history-height);
-      --horizontal-padding: clamp(48px, 7vw, 96px);
-      --horizontal-padding-right: clamp(48px, 8vw, 120px);
-      --horizontal-gap: clamp(18px, 2.6vw, 28px);
-      --horizontal-icon: clamp(18px, 4.6vw, 30px);
-      --vertical-gap: clamp(12px, 4vh, 20px);
+      --horizontal-band-height: clamp(230px, 36vh, 320px);
+      --horizontal-offset: clamp(110px, 22vh, 200px);
+      --horizontal-padding: clamp(48px, 9vw, 128px);
+      --horizontal-gap: clamp(40px, 8vw, 80px);
+      --horizontal-icon: clamp(56px, 12vw, 112px);
+      --vertical-gap: clamp(22px, 6vh, 36px);
+      --vertical-icon: clamp(48px, 10vw, 80px);
       --fade-width: 20%;
-      --icon-size-small: clamp(16px, 3.8vw, 26px);
-      --visible-columns: 8;
-      --focus-column-index: 2;
-      --horizontal-top: calc(var(--row-history-height) * 2);
-      --year-slot-width: calc(
-        (
-          100vw - var(--horizontal-padding) - var(--horizontal-padding-right) -
-          var(--horizontal-gap) * (var(--visible-columns) - 1)
-        ) / var(--visible-columns)
-      );
-      --focus-offset-width: calc(
-        (var(--year-slot-width) + var(--horizontal-gap)) * var(--focus-column-index)
-      );
-      --horizontal-trailing-space: calc((var(--year-slot-width) + var(--horizontal-gap)) * 3);
+      --icon-size-small: clamp(40px, 8vw, 64px);
     }
 
     *, *::before, *::after {
@@ -108,55 +63,49 @@
 
     .xmb-vertical {
       position: absolute;
-      left: calc(var(--horizontal-padding) + var(--focus-offset-width));
-      right: clamp(40px, 22vw, 420px);
-      top: 0;
-      bottom: 0;
+      left: var(--horizontal-padding);
+      right: calc(var(--horizontal-padding) + var(--horizontal-gap));
+      bottom: calc(var(--horizontal-band-height) - clamp(36px, 9vh, 84px));
       display: flex;
-      flex-direction: column;
-      align-items: center;
+      align-items: flex-end;
       justify-content: flex-start;
-      z-index: 2;
+      z-index: 1;
     }
 
     .xmb-vertical__viewport {
-      width: min(420px, 36vw);
-      max-width: 420px;
-      height: 100%;
-      overflow: visible;
+      width: min(420px, 42vw);
+      max-width: 480px;
+      height: clamp(180px, 28vh, 260px);
+      overflow: hidden;
       position: relative;
+      pointer-events: auto;
     }
 
     .xmb-vertical__list {
-      position: relative;
-      width: 100%;
-      min-height: calc(
-        var(--row-history-height) * 2 + var(--horizontal-band-height) +
-        var(--row-spacer-height) + var(--entry-row-height) * 2 + var(--entry-gap)
-      );
-      padding-left: clamp(2px, 1vw, 12px);
-      padding-right: clamp(12px, 2vw, 24px);
-      padding-bottom: clamp(36px, 8vh, 64px);
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--vertical-gap);
+      transform: translateY(0);
+      transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+      padding-left: clamp(4px, 2vw, 16px);
     }
 
     .xmb-entry {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
+      position: relative;
       display: inline-flex;
-      flex-direction: row;
+      flex-direction: column;
       align-items: center;
       justify-content: flex-start;
-      gap: clamp(10px, 2vw, 18px);
-      min-width: clamp(200px, 32vw, 260px);
-      max-width: clamp(260px, 44vw, 340px);
-      padding: clamp(10px, 2vh, 14px) clamp(10px, 2vw, 18px);
+      gap: clamp(10px, 2vh, 18px);
+      min-width: clamp(140px, 32vw, 180px);
+      max-width: clamp(160px, 36vw, 220px);
+      padding: clamp(10px, 2vh, 16px) 0;
       color: var(--text-primary);
-      text-align: left;
-      height: var(--entry-row-height);
-      transform: translateY(var(--entry-offset, 0px));
-      transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1),
+      text-align: center;
+      opacity: 0.55;
+      transform: scale(0.92);
+      transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
         opacity 0.35s ease;
       pointer-events: auto;
     }
@@ -164,15 +113,14 @@
     .xmb-entry__icon {
       width: var(--icon-size-small);
       height: var(--icon-size-small);
-      border-radius: 50%;
+      border-radius: 24px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: calc(var(--icon-size-small) * 0.62);
+      font-size: calc(var(--icon-size-small) * 0.66);
       line-height: 1;
-      background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.55), rgba(56, 189, 248, 0.08) 65%, rgba(15, 23, 42, 0));
-      box-shadow: 0 16px 36px rgba(2, 6, 23, 0.55);
-      flex-shrink: 0;
+      background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.55), rgba(56, 189, 248, 0.1) 65%, rgba(15, 23, 42, 0));
+      box-shadow: 0 18px 46px rgba(2, 6, 23, 0.55);
     }
 
     .xmb-entry__copy {
@@ -180,10 +128,8 @@
       flex-direction: column;
       gap: clamp(4px, 1vh, 8px);
       text-transform: uppercase;
-      font-size: clamp(0.75rem, 1.6vw, 0.9rem);
+      font-size: clamp(0.75rem, 1.8vw, 0.95rem);
       letter-spacing: 0.08em;
-      align-items: flex-start;
-      text-align: left;
     }
 
     .xmb-entry__title {
@@ -194,52 +140,13 @@
 
     .xmb-entry__subtitle {
       color: var(--text-muted);
-      font-size: clamp(0.62rem, 1.4vw, 0.82rem);
+      font-size: clamp(0.65rem, 1.6vw, 0.85rem);
       letter-spacing: 0.06em;
     }
 
     .xmb-entry.is-active {
       opacity: 1;
-    }
-
-    .xmb-entry.is-active .xmb-entry__title {
-      animation: xmbTitlePulse 1.4s ease-in-out infinite alternate;
-    }
-
-    .xmb-entry.is-active .xmb-entry__icon {
-      opacity: 1;
-    }
-
-    .xmb-entry.is-before {
-      opacity: 0.88;
-    }
-
-    .xmb-entry.is-history-slot-1,
-    .xmb-entry.is-history-slot-2 {
-      pointer-events: auto;
-    }
-
-    .xmb-entry.is-history-slot-1 {
-      opacity: 0.88;
-    }
-
-    .xmb-entry.is-history-slot-2 {
-      opacity: 0.8;
-    }
-
-    .xmb-entry.is-hidden {
-      opacity: 0;
-      visibility: hidden;
-      pointer-events: none;
-    }
-
-    .xmb-entry:not(.is-active):not(.is-history-slot-1):not(.is-history-slot-2) .xmb-entry__icon {
-      opacity: 0.6;
-    }
-
-    .xmb-entry:not(.is-active) .xmb-entry__title,
-    .xmb-entry:not(.is-active) .xmb-entry__subtitle {
-      opacity: 0.75;
+      transform: scale(1.08);
     }
 
     .xmb-entry:focus-visible {
@@ -251,63 +158,42 @@
       position: absolute;
       left: 0;
       right: 0;
-      top: var(--horizontal-top);
-      bottom: auto;
+      bottom: var(--horizontal-offset);
       height: var(--horizontal-band-height);
       display: flex;
       align-items: flex-end;
-      padding-bottom: clamp(20px, 5vh, 32px);
+      padding-bottom: clamp(24px, 6vh, 40px);
       background: transparent;
-      z-index: 4;
+      z-index: 3;
     }
 
     .xmb-horizontal__viewport {
       flex: 1;
       overflow: hidden;
       padding-left: var(--horizontal-padding);
-      padding-right: var(--horizontal-padding-right);
+      padding-right: clamp(32px, 6vw, 64px);
       position: relative;
     }
 
-    .xmb-entry:focus-visible {
-      outline: 3px solid var(--accent);
-      outline-offset: 4px;
-    }
-
-    .xmb-horizontal {
-      position: absolute;
-      left: 0;
-      width: 100%;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) var(--axis-column-width) minmax(0, 1fr);
-      column-gap: var(--entry-gap);
-      align-items: center;
-      height: var(--timeline-row-height);
-      top: calc(var(--entry-row-index, 0) * var(--timeline-row-height));
-      z-index: 2;
-      --connector-length: calc(var(--entry-gap) + var(--axis-column-width) / 2);
-    }
-
-    .timeline-entry__column {
+    .xmb-horizontal__track {
       display: flex;
       align-items: flex-end;
       gap: var(--horizontal-gap);
       transform: translateX(0);
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
       will-change: transform;
-      padding-right: var(--horizontal-trailing-space);
+      padding-right: clamp(280px, 40vw, 420px);
     }
 
     .xmb-year {
       position: relative;
       display: inline-flex;
-      flex-direction: row;
+      flex-direction: column;
       align-items: center;
       justify-content: flex-start;
-      gap: clamp(12px, 1.8vw, 18px);
-      min-width: var(--year-slot-width);
-      flex: 0 0 var(--year-slot-width);
-      padding: clamp(6px, 1.4vh, 10px) 0;
+      gap: clamp(12px, 3vh, 20px);
+      min-width: clamp(180px, 26vw, 260px);
+      padding: clamp(8px, 2vh, 12px) 0;
       background: transparent;
       border: none;
       color: var(--text-primary);
@@ -315,42 +201,45 @@
       transform: translateY(0) scale(1);
       transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1),
         color 0.35s ease;
-      opacity: 0.9;
     }
 
     .xmb-year__icon {
       width: var(--horizontal-icon);
       height: var(--horizontal-icon);
-      border-radius: 50%;
+      border-radius: 28px;
       display: inline-flex;
-      flex-direction: row;
       align-items: center;
       justify-content: center;
       font-size: calc(var(--horizontal-icon) * 0.68);
       background: radial-gradient(circle at 35% 35%, rgba(56, 189, 248, 0.65), rgba(56, 189, 248, 0.08) 70%, rgba(15, 23, 42, 0));
-      box-shadow: 0 20px 42px rgba(2, 6, 23, 0.6);
+      box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
     }
 
-    .xmb-year:not(.is-active) .xmb-year__icon {
-      opacity: 0.9;
-    }
-
-    .xmb-year.is-active .xmb-year__icon {
-      opacity: 1;
-    }
-
-    .xmb-year__label {
-      font-weight: 700;
-      font-size: clamp(0.85rem, 1.6vw, 1.05rem);
-      letter-spacing: 0.14em;
+    .xmb-year__copy {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(4px, 1vh, 10px);
+      text-align: center;
       text-transform: uppercase;
-      white-space: nowrap;
+      letter-spacing: 0.1em;
+    }
+
+    .xmb-year__title {
+      font-weight: 700;
+      font-size: clamp(0.95rem, 2.8vw, 1.35rem);
+      color: var(--text-primary);
+    }
+
+    .xmb-year__subtitle {
+      font-size: clamp(0.7rem, 2vw, 0.95rem);
+      color: var(--text-muted);
+      letter-spacing: 0.08em;
     }
 
     .xmb-year.is-active {
-      transform: translateY(-12px) scale(1.12);
+      transform: translateY(-14px) scale(1.16);
       color: #ffffff;
-      opacity: 1;
     }
 
     .xmb-year:focus-visible {
@@ -367,14 +256,6 @@
       background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 90%);
       pointer-events: none;
       z-index: 4;
-    }
-
-    .xmb-year-placeholder {
-      flex: 0 0 var(--year-slot-width);
-      min-width: var(--year-slot-width);
-      height: var(--horizontal-icon);
-      pointer-events: none;
-      opacity: 0;
     }
 
     .xmb-loading {
@@ -395,45 +276,41 @@
       display: none;
     }
 
-    @media (max-width: 960px) {
+    @media (max-width: 900px) {
       :root {
-        --axis-column-width: 120px;
-        --entry-gap: 24px;
-        --timeline-row-height: 176px;
+        --horizontal-band-height: clamp(220px, 42vh, 320px);
+        --horizontal-padding: clamp(28px, 8vw, 72px);
+        --horizontal-gap: clamp(28px, 10vw, 48px);
+        --horizontal-icon: clamp(48px, 14vw, 72px);
+        --vertical-gap: clamp(14px, 4vh, 24px);
+        --vertical-icon: clamp(36px, 10vw, 58px);
       }
-      100% {
-        text-shadow: 0 0 12px rgba(56, 189, 248, 0.9);
+
+      .xmb-vertical__viewport {
+        width: min(420px, 80vw);
+      }
+
+      .xmb-year {
+        min-width: clamp(160px, 44vw, 220px);
       }
     }
 
-    @media (max-width: 900px) {
-      :root {
-        --axis-column-width: 100px;
-        --entry-gap: 18px;
-        --bubble-size: 54px;
-        --timeline-row-height: 168px;
-      }
-
-      .timeline {
-        padding-left: 12px;
-        padding-right: 12px;
-      }
-      
-      .timeline-entry {
-        column-gap: 14px;
+    @media (max-width: 640px) {
+      html, body {
+        overflow: hidden;
       }
 
       .xmb-vertical {
-        left: clamp(24px, 10vw, 40px);
-        right: clamp(20px, 18vw, 60px);
+        left: clamp(20px, 8vw, 32px);
+        right: clamp(20px, 12vw, 40px);
       }
 
       .xmb-vertical__viewport {
         width: 100%;
-        height: 100%;
+        height: clamp(220px, 44vh, 320px);
       }
 
-      .xmb-year__label {
+      .xmb-year__title {
         font-size: clamp(0.95rem, 4vw, 1.2rem);
       }
     }
@@ -460,5 +337,8 @@
   </div>
 
   <script src="timeline.js"></script>
-</body>
+<div data-netlify-deploy-id="68f0642b66127200088703cf" data-netlify-site-id="e7130a7c-7fa0-41b7-be06-ed9d819853e6" data-vcs="github" style="position:fixed">
+  
+  <script async src="/.netlify/scripts/cdp"></script>
+</div></body>
 </html>

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -1,5 +1,4 @@
 (function () {
-  const rootElement = document.documentElement;
   const yearTrack = document.getElementById('timeline-year-track');
   const yearViewport = document.getElementById('year-bar-viewport');
   const entryViewport = document.getElementById('timeline-entry-viewport');
@@ -10,35 +9,27 @@
     return;
   }
 
-  const LEADING_PLACEHOLDER_COUNT = 2;
-
   let yearGroups = [];
   let yearButtons = [];
-  let entryItems = [];
-  let activeYearIndex = 0;
-  let activeEntryIndex = 0;
+  let entryCards = [];
+  let activeYearIndex = -1;
+  let activeEntryIndex = -1;
   let suppressFocusSync = false;
-  let focusColumnOffset = 0;
-  const layoutMetrics = {
-    historyHeight: 0,
-    horizontalHeight: 0,
-    spacerHeight: 0,
-    entryHeight: 0,
-    entryGap: 0,
-  };
 
-  function readCssNumber(variableName, fallback = 0) {
-    const raw = getComputedStyle(rootElement).getPropertyValue(variableName);
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) ? parsed : fallback;
+  function showLoading(message) {
+    if (!loadingBanner) {
+      return;
+    }
+    if (typeof message === 'string' && message.trim()) {
+      loadingBanner.textContent = message.trim();
+    }
+    loadingBanner.classList.remove('is-hidden');
   }
 
-  function refreshLayoutMetrics() {
-    layoutMetrics.historyHeight = readCssNumber('--row-history-height', 96);
-    layoutMetrics.horizontalHeight = readCssNumber('--horizontal-band-height', layoutMetrics.historyHeight);
-    layoutMetrics.spacerHeight = readCssNumber('--row-spacer-height', 24);
-    layoutMetrics.entryHeight = readCssNumber('--entry-row-height', layoutMetrics.historyHeight);
-    layoutMetrics.entryGap = readCssNumber('--entry-gap', 16);
+  function hideLoading() {
+    if (loadingBanner) {
+      loadingBanner.classList.add('is-hidden');
+    }
   }
 
   function limitWords(value, maxWords) {
@@ -55,7 +46,7 @@
     }
     const primaryEvent = group.events[0].event;
     const subtitleSource = primaryEvent.iconLabel || primaryEvent.title || primaryEvent.year || '';
-    return limitWords(subtitleSource, 4);
+    return limitWords(subtitleSource, 6);
   }
 
   function getEventSubtitle(event) {
@@ -63,13 +54,18 @@
       return '';
     }
     if (event.summary) {
-      return limitWords(event.summary, 4);
+      return limitWords(event.summary, 8);
     }
     if (event.title) {
-      return limitWords(event.title, 4);
+      return limitWords(event.title, 8);
     }
-    return limitWords(event.year, 4);
+    return limitWords(event.year, 8);
   }
+
+  function buildYearGroups(data) {
+    if (!Array.isArray(data?.centuries)) {
+      return [];
+    }
 
     const groups = new Map();
 
@@ -86,15 +82,13 @@
             label,
             key,
             events: [],
-            sortValue: Number.isFinite(event.yearValue) ? event.yearValue : null,
+            sortValue: Number.isFinite(event.yearValue) ? event.yearValue : Number.POSITIVE_INFINITY,
           });
         }
         const group = groups.get(key);
-        const yearValue = Number.isFinite(event.yearValue) ? event.yearValue : null;
-        if (Number.isFinite(yearValue)) {
-          if (!Number.isFinite(group.sortValue) || yearValue < group.sortValue) {
-            group.sortValue = yearValue;
-          }
+        const yearValue = Number.isFinite(event.yearValue) ? event.yearValue : Number.POSITIVE_INFINITY;
+        if (!Number.isFinite(group.sortValue) || yearValue < group.sortValue) {
+          group.sortValue = yearValue;
         }
         group.events.push({
           event,
@@ -107,62 +101,31 @@
 
     const ordered = Array.from(groups.values());
     ordered.sort((a, b) => {
-      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.NEGATIVE_INFINITY;
-      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.NEGATIVE_INFINITY;
+      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.POSITIVE_INFINITY;
+      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.POSITIVE_INFINITY;
       if (aValue !== bValue) {
-        return bValue - aValue;
+        return aValue - bValue;
       }
-      return b.label.localeCompare(a.label, undefined, { numeric: true });
+      return a.label.localeCompare(b.label, undefined, { numeric: true });
     });
 
     ordered.forEach((group, index) => {
       group.events.sort((a, b) => {
-        const aValue = Number.isFinite(a.event.yearValue) ? a.event.yearValue : Number.NEGATIVE_INFINITY;
-        const bValue = Number.isFinite(b.event.yearValue) ? b.event.yearValue : Number.NEGATIVE_INFINITY;
+        const aValue = Number.isFinite(a.event.yearValue) ? a.event.yearValue : Number.POSITIVE_INFINITY;
+        const bValue = Number.isFinite(b.event.yearValue) ? b.event.yearValue : Number.POSITIVE_INFINITY;
         if (aValue !== bValue) {
-          return bValue - aValue;
+          return aValue - bValue;
         }
         return a.eventIndex - b.eventIndex;
       });
       const primaryEventWithIcon = group.events.find(entry => entry.event.icon);
       const primaryEvent = group.events[0]?.event;
       group.icon = primaryEventWithIcon?.event?.icon || '🕰️';
-      group.yearLabel = limitWords(primaryEvent?.year || group.label, 2) || `Year ${index + 1}`;
+      group.yearLabel = limitWords(primaryEvent?.year || group.label, 3) || `Year ${index + 1}`;
       group.subtitle = getYearSubtitle(group);
     });
 
     return ordered;
-  }
-
-  function hideLoading() {
-    if (loadingBanner) {
-      loadingBanner.classList.add('is-hidden');
-    }
-  }
-
-  function buildEvent(event, century, bounds) {
-    const position = choosePosition(event);
-    const entry = document.createElement('div');
-    entry.className = 'timeline-entry';
-    entry.dataset.position = position;
-    entry.dataset.eventId = event.id;
-
-    const eventYear = getEventYearValue(event, bounds);
-    if (Number.isFinite(eventYear)) {
-      entry.dataset.yearValue = String(eventYear);
-    }
-  }
-
-  function clearEntryList() {
-    entryList.innerHTML = '';
-    entryList.style.minHeight = '';
-    entryItems = [];
-    activeEntryIndex = 0;
-  }
-
-  function updateFocusOffset() {
-    const firstButton = yearButtons[0];
-    focusColumnOffset = firstButton ? firstButton.offsetLeft : 0;
   }
 
   function alignYearTrack() {
@@ -172,57 +135,88 @@
       return;
     }
 
-    updateFocusOffset();
-
-    const offset = activeButton.offsetLeft;
     const viewportWidth = yearViewport?.clientWidth || 0;
     const trackWidth = yearTrack.scrollWidth;
-    const desired = focusColumnOffset - offset;
-    const lastButton = yearButtons[yearButtons.length - 1];
-    let minTranslate = Math.min(0, viewportWidth - trackWidth);
-    if (lastButton) {
-      const lastRight = lastButton.offsetLeft + lastButton.offsetWidth;
-      const boundary = viewportWidth - lastRight;
-      minTranslate = Math.min(minTranslate, boundary);
-      minTranslate = Math.min(minTranslate, focusColumnOffset - lastButton.offsetLeft);
-    }
+    const buttonCenter = activeButton.offsetLeft + activeButton.offsetWidth / 2;
+    let translate = viewportWidth / 2 - buttonCenter;
+    const minTranslate = Math.min(0, viewportWidth - trackWidth);
     const maxTranslate = 0;
-    const clamped = Math.max(minTranslate, Math.min(maxTranslate, desired));
-    yearTrack.style.transform = `translateX(${clamped}px)`;
+    if (!Number.isFinite(translate)) {
+      translate = 0;
+    }
+    translate = Math.max(minTranslate, Math.min(maxTranslate, translate));
+    yearTrack.style.transform = `translateX(${translate}px)`;
   }
 
-  function applyEntryPositions() {
-    if (!entryItems.length) {
-      entryList.style.minHeight = '';
+  function alignEntryList() {
+    const activeCard = entryCards[activeEntryIndex];
+    if (!activeCard) {
+      entryList.style.transform = 'translateY(0)';
       return;
     }
 
-    refreshLayoutMetrics();
+    const viewportHeight = entryViewport?.clientHeight || 0;
+    const listHeight = entryList.scrollHeight;
+    const cardCenter = activeCard.offsetTop + activeCard.offsetHeight / 2;
+    let translate = viewportHeight / 2 - cardCenter;
+    const minTranslate = Math.min(0, viewportHeight - listHeight);
+    const maxTranslate = 0;
+    if (!Number.isFinite(translate)) {
+      translate = 0;
+    }
+    translate = Math.max(minTranslate, Math.min(maxTranslate, translate));
+    entryList.style.transform = `translateY(${translate}px)`;
+  }
 
-    const baseTop = layoutMetrics.historyHeight * 2 + layoutMetrics.horizontalHeight + layoutMetrics.spacerHeight;
-    const step = layoutMetrics.entryHeight + layoutMetrics.entryGap;
-    const minFutureItems = 2;
+  function clearEntries() {
+    entryList.innerHTML = '';
+    entryList.style.transform = 'translateY(0)';
+    entryCards = [];
+    activeEntryIndex = -1;
+  }
 
-  const rowLayout = {
-    fallbackRowHeight: 184,
-    padding: 112,
-  };
+  function setActiveEntry(index, { focus = false } = {}) {
+    if (!entryCards.length) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(entryCards.length - 1, index));
+    activeEntryIndex = clamped;
 
-  let layoutFrame = null;
+    entryCards.forEach((card, cardIndex) => {
+      const isActive = cardIndex === activeEntryIndex;
+      card.classList.toggle('is-active', isActive);
+      card.tabIndex = isActive ? 0 : -1;
+    });
+
+    const activeCard = entryCards[activeEntryIndex];
+    if (focus && activeCard) {
+      requestAnimationFrame(() => {
+        activeCard.focus({ preventScroll: true });
+      });
+    }
+
+    requestAnimationFrame(alignEntryList);
+  }
 
   function renderEntryList(group) {
-    clearEntryList();
+    clearEntries();
     if (!group || !group.events.length) {
       return;
     }
 
-    group.events.forEach(({ event }) => {
+    const fragment = document.createDocumentFragment();
+
+    group.events.forEach(({ event }, index) => {
       const link = document.createElement('a');
       link.className = 'xmb-entry';
       link.href = `entries/${event.id}.html`;
-      link.setAttribute('role', 'menuitem');
+      link.setAttribute('role', 'option');
       link.setAttribute('aria-label', event.title || event.year || 'Timeline entry');
       link.tabIndex = -1;
+
+      if (event.side) {
+        link.dataset.side = event.side;
+      }
 
       const icon = document.createElement('span');
       icon.className = 'xmb-entry__icon';
@@ -234,7 +228,7 @@
 
       const title = document.createElement('span');
       title.className = 'xmb-entry__title';
-      title.textContent = limitWords(event.iconLabel || event.title || event.year || 'Entry', 2);
+      title.textContent = limitWords(event.iconLabel || event.title || event.year || 'Entry', 6);
       copy.appendChild(title);
 
       const subtitleText = getEventSubtitle(event);
@@ -245,47 +239,79 @@
         copy.appendChild(subtitle);
       }
 
-  function applyRowLayout() {
-    const sections = Array.from(timelineContainer.querySelectorAll('.timeline-century'));
+      link.appendChild(copy);
 
-    sections.forEach(section => {
-      if (section.classList.contains('timeline-century--collapsed')) {
-        return;
-      }
-
-      const entries = section.querySelector('.timeline-century__entries');
-      if (!entries || entries.hidden) {
-        return;
-      }
-
-      const entryNodes = Array.from(entries.querySelectorAll('.timeline-entry'));
-      entryNodes.forEach((entry, index) => {
-        entry.style.setProperty('--entry-row-index', index);
+      link.addEventListener('mouseenter', () => {
+        setActiveEntry(index, { focus: false });
       });
 
-      const computed = window.getComputedStyle(entries);
-      const baseMinHeight = parseFloat(computed.minHeight) || 0;
-      const rowHeightValue = parseFloat(computed.getPropertyValue('--timeline-row-height')) || rowLayout.fallbackRowHeight;
-      const requiredHeight = Math.max(baseMinHeight, entryNodes.length * rowHeightValue + rowLayout.padding);
-      if (requiredHeight > 0) {
-        entries.style.minHeight = `${Math.ceil(requiredHeight)}px`;
-      }
-    });
-
-    requestAnimationFrame(() => {
-      sections.forEach(section => {
-        updateConnectorLengths(section);
+      link.addEventListener('focus', () => {
+        if (suppressFocusSync) {
+          return;
+        }
+        setActiveEntry(index, { focus: false });
       });
+
+      fragment.appendChild(link);
     });
 
-  function scheduleLayout() {
-    if (layoutFrame) {
-      cancelAnimationFrame(layoutFrame);
-    }
-    layoutFrame = requestAnimationFrame(() => {
-      layoutFrame = null;
-      applyRowLayout();
+    entryList.appendChild(fragment);
+    entryCards = Array.from(entryList.querySelectorAll('.xmb-entry'));
+    setActiveEntry(0, { focus: false });
+  }
+
+  function renderYearButtons(groups) {
+    yearTrack.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+
+    groups.forEach((group, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'xmb-year';
+      button.dataset.yearKey = group.key;
+      button.setAttribute('role', 'option');
+      button.setAttribute('aria-selected', 'false');
+      button.setAttribute('aria-label', group.label);
+      button.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'xmb-year__icon';
+      icon.textContent = group.icon;
+      button.appendChild(icon);
+
+      const copy = document.createElement('span');
+      copy.className = 'xmb-year__copy';
+
+      const title = document.createElement('span');
+      title.className = 'xmb-year__title';
+      title.textContent = group.yearLabel;
+      copy.appendChild(title);
+
+      if (group.subtitle) {
+        const subtitle = document.createElement('span');
+        subtitle.className = 'xmb-year__subtitle';
+        subtitle.textContent = group.subtitle;
+        copy.appendChild(subtitle);
+      }
+
+      button.appendChild(copy);
+
+      button.addEventListener('click', () => {
+        setActiveYear(index, { focusYear: true });
+      });
+
+      button.addEventListener('focus', () => {
+        if (suppressFocusSync) {
+          return;
+        }
+        setActiveYear(index, { focusYear: false });
+      });
+
+      fragment.appendChild(button);
     });
+
+    yearTrack.appendChild(fragment);
+    yearButtons = Array.from(yearTrack.querySelectorAll('.xmb-year'));
   }
 
   function setActiveYear(index, { focusYear = false } = {}) {
@@ -296,6 +322,7 @@
     if (clamped === activeYearIndex && !focusYear) {
       return;
     }
+
     activeYearIndex = clamped;
     const group = yearGroups[activeYearIndex];
 
@@ -311,56 +338,8 @@
       }
     });
 
-    alignYearTrack();
     renderEntryList(group);
-  }
-
-  function renderYearButtons(groups) {
-    yearTrack.innerHTML = '';
-
-    for (let i = 0; i < LEADING_PLACEHOLDER_COUNT; i += 1) {
-      const spacer = document.createElement('div');
-      spacer.className = 'xmb-year-placeholder';
-      spacer.setAttribute('aria-hidden', 'true');
-      yearTrack.appendChild(spacer);
-    }
-
-    yearButtons = groups.map((group, index) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'xmb-year';
-      button.dataset.yearKey = group.key;
-      button.setAttribute('role', 'option');
-      button.setAttribute('aria-selected', 'false');
-      button.setAttribute('aria-label', group.label);
-      button.tabIndex = index === 0 ? 0 : -1;
-
-      const icon = document.createElement('span');
-      icon.className = 'xmb-year__icon';
-      icon.textContent = group.icon;
-      button.appendChild(icon);
-
-      const label = document.createElement('span');
-      label.className = 'xmb-year__label';
-      label.textContent = limitWords(group.yearLabel, 2) || `Year ${index + 1}`;
-      button.appendChild(label);
-
-      button.addEventListener('click', () => {
-        setActiveYear(index, { focusYear: true });
-      });
-
-      button.addEventListener('focus', () => {
-        if (suppressFocusSync) {
-          return;
-        }
-        setActiveYear(index, { focusYear: false });
-      });
-
-      yearTrack.appendChild(button);
-      return button;
-    });
-
-    updateFocusOffset();
+    alignYearTrack();
   }
 
   function handleKeydown(event) {
@@ -393,7 +372,7 @@
         break;
       }
       case 'ArrowDown': {
-        if (!entryItems.length) {
+        if (!entryCards.length) {
           return;
         }
         event.preventDefault();
@@ -405,12 +384,12 @@
         break;
       }
       case 'ArrowUp': {
-        if (!entryItems.length) {
+        if (!entryCards.length) {
           return;
         }
         event.preventDefault();
-        if (document.activeElement && entryItems.includes(document.activeElement)) {
-          if (activeEntryIndex === 0) {
+        if (document.activeElement && entryCards.includes(document.activeElement)) {
+          if (activeEntryIndex <= 0) {
             const activeButton = yearButtons[activeYearIndex];
             if (activeButton) {
               suppressFocusSync = true;
@@ -435,13 +414,16 @@
   }
 
   function handleResize() {
-    updateFocusOffset();
-    alignYearTrack();
-    applyEntryPositions();
+    requestAnimationFrame(() => {
+      alignYearTrack();
+      alignEntryList();
+    });
   }
 
   document.addEventListener('keydown', handleKeydown);
   window.addEventListener('resize', handleResize);
+
+  showLoading('Loading timeline…');
 
   fetch('data/timeline.json')
     .then(response => {
@@ -459,7 +441,6 @@
       renderYearButtons(yearGroups);
       hideLoading();
       requestAnimationFrame(() => {
-        refreshLayoutMetrics();
         setActiveYear(0, { focusYear: true });
       });
     })


### PR DESCRIPTION
## Summary
- restyle the timeline shell with the dark theme variables and layout structure that matches the deployed preview
- rebuild the timeline script so year buttons and entry cards render in the new layout and keep alignment, focus, and keyboard interactions working

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68f2eb9f2e6483209a992e59cebade4e