### PR TITLE
Avoid loading external evidence embeds

### DIFF
--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -343,6 +343,21 @@ body[data-theme='dark'] .detail-card {
   margin-bottom: 0.5rem;
 }
 
+.detail-evidence-notice {
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  border: 1px dashed var(--surface-border);
+  background: var(--surface);
+  color: var(--text-soft);
+  font-size: 0.95rem;
+}
+
+.detail-evidence-notice a {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
 .detail-back-link {
   position: fixed;
   top: clamp(18px, 5vw, 32px);

--- a/static/bpvsbuckler/entry.js
+++ b/static/bpvsbuckler/entry.js
@@ -199,6 +199,42 @@
     }
   }
 
+  function isExternalResource(value) {
+    if (!value) {
+      return false;
+    }
+    const trimmed = String(value).trim();
+    if (!trimmed) {
+      return false;
+    }
+    const lower = trimmed.toLowerCase();
+    if (lower.startsWith('data:') || lower.startsWith('blob:')) {
+      return false;
+    }
+
+    try {
+      const parsed = new URL(trimmed, window.location.href);
+      return parsed.origin !== window.location.origin;
+    } catch (error) {
+      return /^(?:https?:)?\/\//i.test(trimmed);
+    }
+  }
+
+  function createExternalNotice(src, title) {
+    const notice = document.createElement('p');
+    notice.className = 'detail-evidence-notice';
+    notice.appendChild(document.createTextNode('External resource: '));
+
+    const link = document.createElement('a');
+    link.href = src;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = title || src;
+    notice.appendChild(link);
+
+    return notice;
+  }
+
   function renderEvidence(event) {
     if (!entryEvidence || !entryEvidenceList) {
       return;
@@ -233,21 +269,26 @@
       }
 
       if (evidence.embed && evidence.embed.type && evidence.embed.src) {
-        if (evidence.embed.type === 'iframe') {
-          const iframe = document.createElement('iframe');
-          iframe.src = evidence.embed.src;
-          iframe.loading = 'lazy';
-          iframe.title = evidence.embed.title || evidence.title;
-          iframe.style.width = '100%';
-          iframe.style.minHeight = '320px';
-          block.appendChild(iframe);
-        } else if (evidence.embed.type === 'object') {
-          const object = document.createElement('object');
-          object.data = evidence.embed.src;
-          object.type = evidence.embed.mime || 'application/pdf';
-          object.style.width = '100%';
-          object.style.minHeight = '320px';
-          block.appendChild(object);
+        const embedSrc = String(evidence.embed.src).trim();
+        if (embedSrc && !isExternalResource(embedSrc)) {
+          if (evidence.embed.type === 'iframe') {
+            const iframe = document.createElement('iframe');
+            iframe.src = embedSrc;
+            iframe.loading = 'lazy';
+            iframe.title = evidence.embed.title || evidence.title;
+            iframe.style.width = '100%';
+            iframe.style.minHeight = '320px';
+            block.appendChild(iframe);
+          } else if (evidence.embed.type === 'object') {
+            const object = document.createElement('object');
+            object.data = embedSrc;
+            object.type = evidence.embed.mime || 'application/pdf';
+            object.style.width = '100%';
+            object.style.minHeight = '320px';
+            block.appendChild(object);
+          }
+        } else if (embedSrc) {
+          block.appendChild(createExternalNotice(embedSrc, evidence.embed.title || evidence.title));
         }
       }
 


### PR DESCRIPTION
## Summary
- stop embedding external evidence documents so the Buckler timeline no longer fetches remote assets
- add styling for notices that link out to external supporting material

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f41b3d784083209c1b7b42ab82cd48