### PR TITLE
Refactor BP vs Buckler entries to load from JSON

### DIFF
--- a/static/bpvsbuckler/entries/1100s-medieval-monastery.html
+++ b/static/bpvsbuckler/entries/1100s-medieval-monastery.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Llandough hosts an early monastery and medieval grange – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Llandough hosts an early monastery and medieval grange</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">12th century • Medieval and Tudor foundations • 1100–1599</p>
-        <h2 id="entry-heading" class="detail-heading">Llandough hosts an early monastery and medieval grange</h2>
-        <p id="entry-summary" class="detail-summary">Long before the Williams family era, the Llandough holding served as a monastic centre and, later, a grange farm leased by Tewkesbury Abbey.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1600s-family-overview.html
+++ b/static/bpvsbuckler/entries/1600s-family-overview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Williams stewardship anchors the family&#x27;s later claims – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams stewardship anchors the family&#x27;s later claims</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1600s • Seventeenth century • 1600–1699</p>
-        <h2 id="entry-heading" class="detail-heading">Williams stewardship anchors the family&#x27;s later claims</h2>
-        <p id="entry-summary" class="detail-summary">Family narratives and estate notes place the Williams ancestors at Great House Farm throughout the Stuart era, laying the foundations for later Buckler claims.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1600s-williams-lease.html
+++ b/static/bpvsbuckler/entries/1600s-williams-lease.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Williams family establishes tenancy at Great House Farm – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams family establishes tenancy at Great House Farm</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">c. 1600 • Seventeenth century • 1600–1699</p>
-        <h2 id="entry-heading" class="detail-heading">Williams family establishes tenancy at Great House Farm</h2>
-        <p id="entry-summary" class="detail-summary">Family oral history places the Williams ancestors on Great House Farm at the start of the seventeenth century, beginning a four-hundred-year relationship with the Llandough holding.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1650s-farmstead-notes.html
+++ b/static/bpvsbuckler/entries/1650s-farmstead-notes.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Estate surveys describe the seventeenth-century farmstead – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Estate surveys describe the seventeenth-century farmstead</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">Mid-1600s • Seventeenth century • 1600–1699</p>
-        <h2 id="entry-heading" class="detail-heading">Estate surveys describe the seventeenth-century farmstead</h2>
-        <p id="entry-summary" class="detail-summary">Estate notes quoted in the family blog describe Great House Farm's orchard, meadow, and dovecote while confirming Williams stewardship through the Commonwealth period.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1700s-family-overview.html
+++ b/static/bpvsbuckler/entries/1700s-family-overview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Eighteenth-century records confirm Williams continuity – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Eighteenth-century records confirm Williams continuity</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1700s • Eighteenth century • 1700–1799</p>
-        <h2 id="entry-heading" class="detail-heading">Eighteenth-century records confirm Williams continuity</h2>
-        <p id="entry-summary" class="detail-summary">Parish registers and estate correspondence cited in the blog show the Williams family maintaining possession across the eighteenth century.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1700s-parish-registers.html
+++ b/static/bpvsbuckler/entries/1700s-parish-registers.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Parish registers maintain the Williams line at Llandough – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Parish registers maintain the Williams line at Llandough</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1700s • Eighteenth century • 1700–1799</p>
-        <h2 id="entry-heading" class="detail-heading">Parish registers maintain the Williams line at Llandough</h2>
-        <p id="entry-summary" class="detail-summary">Baptisms, marriages, and burials reproduced in the blog demonstrate that successive Williams generations remained at Great House Farm throughout the eighteenth century.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1790s-bute-renewal.html
+++ b/static/bpvsbuckler/entries/1790s-bute-renewal.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Estate correspondence renews the family&#x27;s tenure – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Estate correspondence renews the family&#x27;s tenure</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">Late 1700s • Eighteenth century • 1700–1799</p>
-        <h2 id="entry-heading" class="detail-heading">Estate correspondence renews the family&#x27;s tenure</h2>
-        <p id="entry-summary" class="detail-summary">According to the blog, late eighteenth-century letters from the Bute estate confirmed the Williams family's continued tenancy and obligations at Great House Farm.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1800s-family-overview.html
+++ b/static/bpvsbuckler/entries/1800s-family-overview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Victorian sources trace the shift toward the Bucklers – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Victorian sources trace the shift toward the Bucklers</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1800s • Nineteenth century • 1800–1899</p>
-        <h2 id="entry-heading" class="detail-heading">Victorian sources trace the shift toward the Bucklers</h2>
-        <p id="entry-summary" class="detail-summary">Victorian-era maps and marriages documented in the blog show the Williams holding transitioning toward the Buckler family by the end of the nineteenth century.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1840s-tithe-map.html
+++ b/static/bpvsbuckler/entries/1840s-tithe-map.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tithe surveys list Great House Farm under Williams occupation – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Tithe surveys list Great House Farm under Williams occupation</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1840s • Nineteenth century • 1800–1899</p>
-        <h2 id="entry-heading" class="detail-heading">Tithe surveys list Great House Farm under Williams occupation</h2>
-        <p id="entry-summary" class="detail-summary">Tithe apportionments cited in the blog record Great House Farm, its orchard, and meadow being worked by the Williams family in mid-nineteenth-century Llandough.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1880s-soldier-find.html
+++ b/static/bpvsbuckler/entries/1880s-soldier-find.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">c. 1880 • Nineteenth century • 1800–1899</p>
-        <h2 id="entry-heading" class="detail-heading">Victorians uncover a medieval soldier&#x27;s remains beneath the farmhouse</h2>
-        <p id="entry-summary" class="detail-summary">Late nineteenth-century renovations exposed the skeleton of an armoured horseman beneath the dining room floor, fuelling stories of medieval conflict at Great House Farm.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1890s-buckler-marriage.html
+++ b/static/bpvsbuckler/entries/1890s-buckler-marriage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Williams heirs marry into the Buckler family – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Williams heirs marry into the Buckler family</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1890s • Nineteenth century • 1800–1899</p>
-        <h2 id="entry-heading" class="detail-heading">Williams heirs marry into the Buckler family</h2>
-        <p id="entry-summary" class="detail-summary">The blog notes that late nineteenth-century marriages connected the Williams daughters to Frederick Buckler, setting the stage for Mary Buckler (née Williams) to claim inheritance of the farm.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1897-marconi-visit.html
+++ b/static/bpvsbuckler/entries/1897-marconi-visit.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Marconi conducts wireless experiments with help from Great House Farm – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Marconi conducts wireless experiments with help from Great House Farm</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1897 • Nineteenth century • 1800–1899</p>
-        <h2 id="entry-heading" class="detail-heading">Marconi conducts wireless experiments with help from Great House Farm</h2>
-        <p id="entry-summary" class="detail-summary">In May 1897 Guglielmo Marconi stayed at Great House Farm while organising the pioneering wireless telegraphy tests between Lavernock Point and Flat Holm, relying on the Williams family for transport and support.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1900s-family-overview.html
+++ b/static/bpvsbuckler/entries/1900s-family-overview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Twentieth-century battles end in the Court of Appeal – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Twentieth-century battles end in the Court of Appeal</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1980s • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Twentieth-century battles end in the Court of Appeal</h2>
-        <p id="entry-summary" class="detail-summary">Twentieth-century tenancies, litigation, and community advocacy culminated in the Court of Appeal decision in <em>BP v Buckler</em> (1987).</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1916-tenancy.html
+++ b/static/bpvsbuckler/entries/1916-tenancy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Yearly tenancy granted to John Williams – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Yearly tenancy granted to John Williams</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1916 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Yearly tenancy granted to John Williams</h2>
-        <p id="entry-summary" class="detail-summary">The Marquess of Bute lets Great House Farm, including its farmhouse and garden, to John Williams—Mary Buckler's father—on an agricultural yearly tenancy.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1938-reversion.html
+++ b/static/bpvsbuckler/entries/1938-reversion.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reversion conveyed to Western Ground Rents – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Reversion conveyed to Western Ground Rents</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1938 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Reversion conveyed to Western Ground Rents</h2>
-        <p id="entry-summary" class="detail-summary">Estate management company Western Ground Rents Ltd. acquires the reversionary interest in Great House Farm. Frederick Buckler succeeds to the protected tenancy after marrying Mary Williams.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1953-arrears.html
+++ b/static/bpvsbuckler/entries/1953-arrears.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Last rent payment under court pressure – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Last rent payment under court pressure</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1953 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Last rent payment under court pressure</h2>
-        <p id="entry-summary" class="detail-summary">Frederick Buckler makes the final recorded rent payment for the farmhouse and garden pursuant to a county court judgment for arrears.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1955-notice.html
+++ b/static/bpvsbuckler/entries/1955-notice.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Notice to quit and Order 14 possession judgment – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Notice to quit and Order 14 possession judgment</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1955 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Notice to quit and Order 14 possession judgment</h2>
-        <p id="entry-summary" class="detail-summary">Western Ground Rents serves a statutory notice to quit on the Bucklers and successfully seeks summary judgment for possession and mesne profits under the then Order 14 procedure.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1959-ownership-claim.html
+++ b/static/bpvsbuckler/entries/1959-ownership-claim.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mary Buckler asserts inherited ownership – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler asserts inherited ownership</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1959 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Mary Buckler asserts inherited ownership</h2>
-        <p id="entry-summary" class="detail-summary">Mary Buckler concludes that her family already owns Great House Farm by inheritance from her grandfather John Williams and refuses further tenancy overtures.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1960s-land-developed.html
+++ b/static/bpvsbuckler/entries/1960s-land-developed.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Housing estate and school rise on Great House Farm&#x27;s former fields – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Housing estate and school rise on Great House Farm&#x27;s former fields</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1960s • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Housing estate and school rise on Great House Farm&#x27;s former fields</h2>
-        <p id="entry-summary" class="detail-summary">By the late 1960s Great House Farm's acreage was carved up for suburban housing and, in 1970, a new primary school, shrinking the land surrounding the farmhouse.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1962-high-court.html
+++ b/static/bpvsbuckler/entries/1962-high-court.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Western Ground Rents files High Court action – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Western Ground Rents files High Court action</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1962 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Western Ground Rents files High Court action</h2>
-        <p id="entry-summary" class="detail-summary">The company commences fresh proceedings in the High Court seeking possession of the farmhouse and garden together with mesne profits accruing since 1955.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1963-committal.html
+++ b/static/bpvsbuckler/entries/1963-committal.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Suspended committal order against Frederick Buckler – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Suspended committal order against Frederick Buckler</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1963 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Suspended committal order against Frederick Buckler</h2>
-        <p id="entry-summary" class="detail-summary">A judge issues, then suspends, a committal order against Frederick Buckler for failing to give up possession in obedience to the 1955 order.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1965-tenancy-offer.html
+++ b/static/bpvsbuckler/entries/1965-tenancy-offer.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mary Buckler refuses renewed tenancy – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler refuses renewed tenancy</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1965 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Mary Buckler refuses renewed tenancy</h2>
-        <p id="entry-summary" class="detail-summary">Western Ground Rents seeks to regularise matters by offering Mary Buckler a fresh tenancy; she declines, insisting she already owns the property.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1967-frederick-death.html
+++ b/static/bpvsbuckler/entries/1967-frederick-death.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Frederick Buckler dies; Mary and children remain – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Frederick Buckler dies; Mary and children remain</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1965–1967 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Frederick Buckler dies; Mary and children remain</h2>
-        <p id="entry-summary" class="detail-summary">Frederick Buckler passes away in the mid-1960s, leaving Mary Buckler and their children—William among them—in sole occupation of the farmhouse.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1969-sale-to-bp.html
+++ b/static/bpvsbuckler/entries/1969-sale-to-bp.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BP Pension Trust purchases the estate – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">BP Pension Trust purchases the estate</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1969 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">BP Pension Trust purchases the estate</h2>
-        <p id="entry-summary" class="detail-summary">Western Ground Rents sells Great House Farm and the surrounding estate to BP Pension Trust Ltd., passing on the benefit of prior possession orders.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1974-cc-proceedings.html
+++ b/static/bpvsbuckler/entries/1974-cc-proceedings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BP issues county court proceedings but offers licence – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">BP issues county court proceedings but offers licence</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1974 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">BP issues county court proceedings but offers licence</h2>
-        <p id="entry-summary" class="detail-summary">BP Pension Trust issues fresh possession proceedings but, under pressure from a 1,700-signature petition, writes to Mary Buckler offering a rent-free licence that would acknowledge BP's title.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1976-parliament.html
+++ b/static/bpvsbuckler/entries/1976-parliament.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Case raised in the House of Commons – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Case raised in the House of Commons</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1976 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Case raised in the House of Commons</h2>
-        <p id="entry-summary" class="detail-summary">MPs reference the Buckler family's position during a Westminster debate on housing hardship in Cardiff, pressing ministers on BP's stewardship of Great House Farm.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1979-roman-villa.html
+++ b/static/bpvsbuckler/entries/1979-roman-villa.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Roman villa remains are discovered on former Great House Farm land – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Roman villa remains are discovered on former Great House Farm land</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1979 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Roman villa remains are discovered on former Great House Farm land</h2>
-        <p id="entry-summary" class="detail-summary">Construction work on the southern fields in 1979 exposed the remains of a second- to fourth-century Roman villa, complete with mosaic flooring and a hypocaust bath system.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1983-mary-buckler-death.html
+++ b/static/bpvsbuckler/entries/1983-mary-buckler-death.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mary Buckler&#x27;s passing leaves her son to continue the fight – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Mary Buckler&#x27;s passing leaves her son to continue the fight</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1983 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Mary Buckler&#x27;s passing leaves her son to continue the fight</h2>
-        <p id="entry-summary" class="detail-summary">Mary Buckler (née Williams) dies in 1983 after decades at Great House Farm, leaving her son William to press the family's adverse possession claim alone.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1985-county-court.html
+++ b/static/bpvsbuckler/entries/1985-county-court.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>County court finds licence defeats adverse possession – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">County court finds licence defeats adverse possession</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1985 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">County court finds licence defeats adverse possession</h2>
-        <p id="entry-summary" class="detail-summary">A Cardiff County Court judge holds that BP's 1974 letters created a licence, preventing William Buckler from completing the 12-year adverse possession period. Judgment is entered for BP, with execution stayed to allow an appeal.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1987-court-of-appeal.html
+++ b/static/bpvsbuckler/entries/1987-court-of-appeal.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Court of Appeal dismisses William Buckler&#x27;s appeal – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Court of Appeal dismisses William Buckler&#x27;s appeal</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1987 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Court of Appeal dismisses William Buckler&#x27;s appeal</h2>
-        <p id="entry-summary" class="detail-summary">On 17 February 1987 the Court of Appeal (Slade, Croom-Johnson and Nourse LJJ) rules that BP's 1974 letters granted an unrevoked licence, interrupting adverse possession. William Buckler's appeal is dismissed.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1988-demolition.html
+++ b/static/bpvsbuckler/entries/1988-demolition.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Great House Farm is demolished after 33 years of dispute – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Great House Farm is demolished after 33 years of dispute</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1988 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Great House Farm is demolished after 33 years of dispute</h2>
-        <p id="entry-summary" class="detail-summary">On the night of 6 December 1988 BP Properties demolished Great House Farm soon after securing legal victory, ending the Williams/Buckler family's four centuries on the site.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1990-archaeology-watch.html
+++ b/static/bpvsbuckler/entries/1990-archaeology-watch.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archaeologists survey the cleared site ahead of redevelopment – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Archaeologists survey the cleared site ahead of redevelopment</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1990 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Archaeologists survey the cleared site ahead of redevelopment</h2>
-        <p id="entry-summary" class="detail-summary">Trial trenches dug by the Glamorgan-Gwent Archaeological Trust in 1990 mapped the demolished farmhouse and recommended watching briefs for the most sensitive areas before construction proceeded.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1991-commentary.html
+++ b/static/bpvsbuckler/entries/1991-commentary.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Academic commentary consolidates the precedent – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Academic commentary consolidates the precedent</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1991 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Academic commentary consolidates the precedent</h2>
-        <p id="entry-summary" class="detail-summary">Property law textbooks and journals adopt <em>BP v Buckler</em> as a leading example of licences stopping adverse possession clock.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entries/1994-cemetery-excavation.html
+++ b/static/bpvsbuckler/entries/1994-cemetery-excavation.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Excavation uncovers an early-medieval cemetery beneath the farm – Great House Farm</title>
+  <title>Loading entry… – Great House Farm timeline</title>
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="../entry.css">
 </head>
@@ -11,14 +11,14 @@
   <div class="container mx-auto px-4 py-10">
     <header class="text-center">
       <div class="flex flex-col items-center gap-4">
-        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Great House Farm</h1>
-        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Excavation uncovers an early-medieval cemetery beneath the farm</p>
+        <h1 id="case-title" class="text-4xl md:text-5xl font-extrabold tracking-tight page-title">Loading timeline…</h1>
+        <p id="case-subtitle" class="text-lg md:text-xl max-w-3xl mx-auto page-subtitle">Loading entry details…</p>
       </div>
       <div id="century-selector" class="mt-8 flex flex-col items-center gap-3">
         <label for="century-select" class="text-xs font-semibold tracking-[0.28em] uppercase text-slate-500 dark:text-slate-300">Century</label>
         <div class="controls-group">
           <div class="controls-group__buttons">
-            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch to dark theme">
+            <button id="theme-toggle" class="round-button" type="button" aria-pressed="false" title="Switch theme">
               <span class="sr-only">Toggle colour theme</span>
               <span aria-hidden="true" data-theme-icon>☀️</span>
             </button>
@@ -35,7 +35,7 @@
       <div id="intro-panel" class="intro-panel hidden" aria-hidden="true" tabindex="-1">
         <div class="intro-panel__header">
           <h2 class="text-2xl font-semibold intro-heading">About this timeline</h2>
-          <button id="intro-close" class="intro-panel__close" type="button" aria-label="Close introduction">&times;</button>
+          <button id="intro-close" class="intro-panel__close hidden" type="button" aria-label="Close introduction">&times;</button>
         </div>
         <div id="case-intro" class="intro-body space-y-4"></div>
         <div id="key-themes" class="intro-grid"></div>
@@ -44,9 +44,9 @@
 
     <main class="detail-content">
       <article class="detail-card">
-        <p id="entry-meta" class="detail-meta">1994 • Twentieth century • 1900–1999</p>
-        <h2 id="entry-heading" class="detail-heading">Excavation uncovers an early-medieval cemetery beneath the farm</h2>
-        <p id="entry-summary" class="detail-summary">Before new housing went up in 1994, archaeologists excavated 1,026 burials dating from the seventh to tenth centuries, proving that Great House Farm once formed part of a major monastic settlement.</p>
+        <p id="entry-meta" class="detail-meta">Loading metadata…</p>
+        <h2 id="entry-heading" class="detail-heading">Loading entry…</h2>
+        <p id="entry-summary" class="detail-summary">Please wait while we load the entry details.</p>
         <section id="entry-context" class="detail-section hidden">
           <h3>Context</h3>
           <ul id="entry-context-list"></ul>
@@ -55,14 +55,16 @@
           <h3>Evidence &amp; records</h3>
           <div id="entry-evidence-list" class="detail-evidence-grid"></div>
         </section>
-        <a href="../index.html" class="detail-back-button">
+        <a href="../index.html" class="detail-back-button detail-back-link">
           <span class="detail-back-button__icon" aria-hidden="true">◀</span>
           <span class="sr-only">Back to timeline</span>
         </a>
       </article>
     </main>
   </div>
-
+  <noscript>
+    <p class="noscript-warning">JavaScript is required to load this entry. Please enable JavaScript and reload the page.</p>
+  </noscript>
   <script src="../entry.js"></script>
 </body>
 </html>

--- a/static/bpvsbuckler/entry.css
+++ b/static/bpvsbuckler/entry.css
@@ -397,6 +397,17 @@ body[data-theme='dark'] .detail-back-link {
   color: #0f172a;
 }
 
+.noscript-warning {
+  margin: 2rem auto 0;
+  max-width: 720px;
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  text-align: center;
+  border: 1px dashed var(--surface-border);
+}
+
 @media (max-width: 768px) {
   .round-button {
     width: 40px;

--- a/static/bpvsbuckler/entry.js
+++ b/static/bpvsbuckler/entry.js
@@ -1,6 +1,20 @@
 (function () {
   const body = document.body;
-  const entryId = body.dataset.entryId;
+
+  function deriveEntryId() {
+    const datasetValue = body?.dataset?.entryId;
+    if (datasetValue) {
+      return datasetValue;
+    }
+    const path = window.location.pathname || '';
+    const match = path.match(/([^/]+?)(?:\.html)?$/);
+    if (match && match[1]) {
+      return decodeURIComponent(match[1]);
+    }
+    return null;
+  }
+
+  const entryId = deriveEntryId();
   const storageKey = 'ghf-theme';
 
   const themeToggle = document.getElementById('theme-toggle');
@@ -423,9 +437,25 @@
       document.title = pageTitle;
     } else if (entrySummary) {
       entrySummary.textContent = 'We could not find details for this timeline entry.';
+      if (entryMeta) {
+        entryMeta.textContent = '';
+      }
     }
 
     populateCenturies(centuriesData, selectedCenturyValue);
+  }
+
+  if (!entryId) {
+    if (entrySummary) {
+      entrySummary.textContent = 'We could not determine which entry to load.';
+    }
+    if (entryMeta) {
+      entryMeta.textContent = '';
+    }
+    if (centurySelector) {
+      centurySelector.classList.add('hidden');
+    }
+    return;
   }
 
   fetch('../data/timeline.json')


### PR DESCRIPTION
## Summary
- replace each BP vs Buckler entry page with a shared shell that loads content from the existing timeline JSON
- update the entry loader script to derive the entry id from the URL, handle missing data more gracefully, and clear metadata when data is unavailable
- add a small noscript notice style to keep the template accessible when JavaScript is disabled

## Testing
- not run (static content change only)

------
https://chatgpt.com/codex/tasks/task_e_68f43c28579c8320a9f783146180b150