### PR TITLE
Center horizontal timeline navigation and constrain to eight items

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -17,7 +17,16 @@
       --horizontal-gap: clamp(10px, 2vw, 20px);
       --horizontal-icon: clamp(48px, 10vw, 80px);
       --horizontal-safe-zone: clamp(32px, 9vh, 72px);
-      --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
+      --horizontal-band-max-width: min(100vw, 1280px);
+      --horizontal-item-width: clamp(
+        56px,
+        calc(
+          (var(--horizontal-band-max-width) - (2 * var(--horizontal-padding)) - (7 * var(--horizontal-gap))) /
+            8
+        ),
+        160px
+      );
+      --horizontal-icon-size: min(var(--horizontal-icon), calc(var(--horizontal-item-width) * 0.78));
       --vertical-gap: clamp(22px, 6vh, 36px);
       --vertical-icon: clamp(48px, 10vw, 80px);
       --fade-width: 20%;
@@ -66,12 +75,13 @@
       position: absolute;
       left: var(--horizontal-padding);
       right: calc(var(--horizontal-padding) + var(--horizontal-gap));
-      bottom: calc(var(--horizontal-band-height) - clamp(36px, 9vh, 84px));
+      top: calc(50% + (var(--horizontal-band-height) / 2) + clamp(18px, 3vh, 36px));
+      bottom: clamp(32px, 8vh, 72px);
       display: flex;
       align-items: flex-end;
       justify-content: flex-start;
-      padding-bottom: calc(var(--horizontal-safe-zone) + clamp(12px, 3vh, 28px));
-      z-index: 1;
+      padding-bottom: clamp(12px, 3vh, 28px);
+      z-index: 2;
     }
 
     .xmb-vertical__viewport {
@@ -166,17 +176,19 @@
       min-height: var(--horizontal-band-height);
       display: flex;
       align-items: center;
+      justify-content: center;
       padding: var(--horizontal-safe-zone) 0;
       background: transparent;
       z-index: 3;
     }
 
     .xmb-horizontal__viewport {
-      flex: 1;
+      flex: 0 1 var(--horizontal-band-max-width);
+      width: min(100%, var(--horizontal-band-max-width));
       height: 100%;
       overflow: hidden;
       padding-left: var(--horizontal-padding);
-      padding-right: clamp(24px, 5vw, 48px);
+      padding-right: var(--horizontal-padding);
       position: relative;
       display: flex;
       align-items: center;
@@ -185,7 +197,9 @@
     .xmb-horizontal__track {
       display: flex;
       align-items: center;
+      justify-content: flex-start;
       gap: var(--horizontal-gap);
+      min-width: 100%;
       transform: translateX(0);
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
       will-change: transform;
@@ -213,13 +227,13 @@
     }
 
     .xmb-year__icon {
-      width: var(--horizontal-icon);
-      height: var(--horizontal-icon);
+      width: var(--horizontal-icon-size);
+      height: var(--horizontal-icon-size);
       border-radius: 28px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: calc(var(--horizontal-icon) * 0.68);
+      font-size: calc(var(--horizontal-icon-size) * 0.68);
       background: radial-gradient(circle at 35% 35%, rgba(56, 189, 248, 0.65), rgba(56, 189, 248, 0.08) 70%, rgba(15, 23, 42, 0));
       box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
     }
@@ -294,7 +308,15 @@
         --horizontal-safe-zone: clamp(24px, 8vh, 64px);
         --vertical-gap: clamp(14px, 4vh, 24px);
         --vertical-icon: clamp(36px, 10vw, 58px);
-        --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
+        --horizontal-band-max-width: min(100vw, 960px);
+        --horizontal-item-width: clamp(
+          52px,
+          calc(
+            (var(--horizontal-band-max-width) - (2 * var(--horizontal-padding)) - (7 * var(--horizontal-gap))) /
+              8
+          ),
+          132px
+        );
       }
 
       .xmb-vertical__viewport {
@@ -314,7 +336,15 @@
         --horizontal-gap: clamp(6px, 1.8vw, 12px);
         --horizontal-icon: clamp(36px, 14vw, 56px);
         --horizontal-safe-zone: clamp(20px, 9vh, 56px);
-        --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
+        --horizontal-band-max-width: min(100vw, 720px);
+        --horizontal-item-width: clamp(
+          48px,
+          calc(
+            (var(--horizontal-band-max-width) - (2 * var(--horizontal-padding)) - (7 * var(--horizontal-gap))) /
+              8
+          ),
+          120px
+        );
       }
 
       html, body {

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -12,11 +12,12 @@
       --text-primary: #f8fafc;
       --text-muted: rgba(226, 232, 240, 0.6);
       --accent: #38bdf8;
-      --horizontal-band-height: clamp(230px, 36vh, 320px);
-      --horizontal-offset: clamp(110px, 22vh, 200px);
+      --horizontal-band-height: clamp(210px, 34vh, 300px);
       --horizontal-padding: clamp(48px, 9vw, 128px);
-      --horizontal-gap: clamp(40px, 8vw, 80px);
-      --horizontal-icon: clamp(56px, 12vw, 112px);
+      --horizontal-gap: clamp(10px, 2vw, 20px);
+      --horizontal-icon: clamp(48px, 10vw, 80px);
+      --horizontal-safe-zone: clamp(32px, 9vh, 72px);
+      --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
       --vertical-gap: clamp(22px, 6vh, 36px);
       --vertical-icon: clamp(48px, 10vw, 80px);
       --fade-width: 20%;
@@ -69,6 +70,7 @@
       display: flex;
       align-items: flex-end;
       justify-content: flex-start;
+      padding-bottom: calc(var(--horizontal-safe-zone) + clamp(12px, 3vh, 28px));
       z-index: 1;
     }
 
@@ -158,41 +160,48 @@
       position: absolute;
       left: 0;
       right: 0;
-      bottom: var(--horizontal-offset);
-      height: var(--horizontal-band-height);
+      top: 50%;
+      bottom: auto;
+      transform: translateY(-50%);
+      min-height: var(--horizontal-band-height);
       display: flex;
-      align-items: flex-end;
-      padding-bottom: clamp(24px, 6vh, 40px);
+      align-items: center;
+      padding: var(--horizontal-safe-zone) 0;
       background: transparent;
       z-index: 3;
     }
 
     .xmb-horizontal__viewport {
       flex: 1;
+      height: 100%;
       overflow: hidden;
       padding-left: var(--horizontal-padding);
-      padding-right: clamp(32px, 6vw, 64px);
+      padding-right: clamp(24px, 5vw, 48px);
       position: relative;
+      display: flex;
+      align-items: center;
     }
 
     .xmb-horizontal__track {
       display: flex;
-      align-items: flex-end;
+      align-items: center;
       gap: var(--horizontal-gap);
       transform: translateX(0);
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
       will-change: transform;
-      padding-right: clamp(280px, 40vw, 420px);
+      padding-right: 0;
     }
 
     .xmb-year {
       position: relative;
-      display: inline-flex;
+      display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
-      gap: clamp(12px, 3vh, 20px);
-      min-width: clamp(180px, 26vw, 260px);
+      gap: clamp(12px, 3vh, 18px);
+      flex: 0 0 var(--horizontal-item-width);
+      min-width: var(--horizontal-item-width);
+      max-width: var(--horizontal-item-width);
       padding: clamp(8px, 2vh, 12px) 0;
       background: transparent;
       border: none;
@@ -249,8 +258,8 @@
 
     .xmb-horizontal__fade {
       position: absolute;
-      top: clamp(12px, 3vh, 24px);
-      bottom: clamp(12px, 3vh, 24px);
+      top: 0;
+      bottom: 0;
       right: 0;
       width: var(--fade-width);
       background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 90%);
@@ -278,12 +287,14 @@
 
     @media (max-width: 900px) {
       :root {
-        --horizontal-band-height: clamp(220px, 42vh, 320px);
+        --horizontal-band-height: clamp(200px, 40vh, 280px);
         --horizontal-padding: clamp(28px, 8vw, 72px);
-        --horizontal-gap: clamp(28px, 10vw, 48px);
-        --horizontal-icon: clamp(48px, 14vw, 72px);
+        --horizontal-gap: clamp(8px, 2.4vw, 16px);
+        --horizontal-icon: clamp(44px, 12vw, 66px);
+        --horizontal-safe-zone: clamp(24px, 8vh, 64px);
         --vertical-gap: clamp(14px, 4vh, 24px);
         --vertical-icon: clamp(36px, 10vw, 58px);
+        --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
       }
 
       .xmb-vertical__viewport {
@@ -291,11 +302,21 @@
       }
 
       .xmb-year {
-        min-width: clamp(160px, 44vw, 220px);
+        min-width: var(--horizontal-item-width);
+        max-width: var(--horizontal-item-width);
       }
     }
 
     @media (max-width: 640px) {
+      :root {
+        --horizontal-band-height: clamp(190px, 44vh, 260px);
+        --horizontal-padding: clamp(16px, 6vw, 28px);
+        --horizontal-gap: clamp(6px, 1.8vw, 12px);
+        --horizontal-icon: clamp(36px, 14vw, 56px);
+        --horizontal-safe-zone: clamp(20px, 9vh, 56px);
+        --horizontal-item-width: calc((100% - (7 * var(--horizontal-gap))) / 8);
+      }
+
       html, body {
         overflow: hidden;
       }

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -14,6 +14,7 @@
   let entryCards = [];
   let activeYearIndex = -1;
   let activeEntryIndex = -1;
+  let yearTrackOffset = 0;
   let suppressFocusSync = false;
 
   function showLoading(message) {
@@ -131,21 +132,40 @@
   function alignYearTrack() {
     const activeButton = yearButtons[activeYearIndex];
     if (!activeButton) {
+      yearTrackOffset = 0;
       yearTrack.style.transform = 'translateX(0)';
       return;
     }
 
     const viewportWidth = yearViewport?.clientWidth || 0;
     const trackWidth = yearTrack.scrollWidth;
-    const buttonCenter = activeButton.offsetLeft + activeButton.offsetWidth / 2;
-    let translate = viewportWidth / 2 - buttonCenter;
-    const minTranslate = Math.min(0, viewportWidth - trackWidth);
-    const maxTranslate = 0;
-    if (!Number.isFinite(translate)) {
-      translate = 0;
+    if (trackWidth <= viewportWidth) {
+      yearTrackOffset = 0;
+      yearTrack.style.transform = 'translateX(0)';
+      return;
     }
-    translate = Math.max(minTranslate, Math.min(maxTranslate, translate));
-    yearTrack.style.transform = `translateX(${translate}px)`;
+
+    const buttonLeft = activeButton.offsetLeft;
+    const buttonRight = buttonLeft + activeButton.offsetWidth;
+    const visibleLeft = -yearTrackOffset;
+    const visibleRight = visibleLeft + viewportWidth;
+
+    if (buttonLeft < visibleLeft) {
+      yearTrackOffset = -buttonLeft;
+    } else if (buttonRight > visibleRight) {
+      yearTrackOffset = viewportWidth - buttonRight;
+    }
+
+    const minOffset = Math.min(0, viewportWidth - trackWidth);
+    const maxOffset = 0;
+
+    if (!Number.isFinite(yearTrackOffset)) {
+      yearTrackOffset = 0;
+    } else {
+      yearTrackOffset = Math.max(minOffset, Math.min(maxOffset, yearTrackOffset));
+    }
+
+    yearTrack.style.transform = `translateX(${yearTrackOffset}px)`;
   }
 
   function alignEntryList() {
@@ -312,6 +332,8 @@
 
     yearTrack.appendChild(fragment);
     yearButtons = Array.from(yearTrack.querySelectorAll('.xmb-year'));
+    yearTrackOffset = 0;
+    yearTrack.style.transform = 'translateX(0)';
   }
 
   function setActiveYear(index, { focusYear = false } = {}) {


### PR DESCRIPTION
## Summary
- center the horizontal timeline navigation band and size each year tile so eight entries are visible while the rest overflow to the right
- add vertical padding to the horizontal bar and surrounding layout to keep it visually separated from the vertical menu
- update the year track alignment logic so keyboard navigation keeps items in view without requiring scrollbars

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4744bc688832095f0a479580314cd