### PR TITLE
Refine timeline icon sizing and spacing

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -15,7 +15,7 @@
       --horizontal-band-height: clamp(230px, 36vh, 320px);
       --horizontal-offset: clamp(110px, 22vh, 200px);
       --horizontal-gap: clamp(28px, 6vw, 60px);
-      --horizontal-icon: clamp(48px, 10vw, 80px);
+      --horizontal-icon: clamp(40px, 8vw, 64px);
       --vertical-gap: clamp(22px, 6vh, 36px);
       --vertical-icon: clamp(48px, 10vw, 80px);
       --fade-width: 20%;
@@ -101,9 +101,9 @@
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
-      gap: clamp(12px, 3vh, 20px);
-      min-width: clamp(160px, 24vw, 220px);
-      padding: clamp(8px, 2vh, 12px) 0;
+      gap: clamp(10px, 2.5vh, 18px);
+      min-width: clamp(150px, 22vw, 210px);
+      padding: clamp(6px, 1.8vh, 10px) 0;
       color: var(--text-primary);
       text-align: center;
       opacity: 0.7;
@@ -120,7 +120,7 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: calc(var(--horizontal-icon) * 0.68);
+      font-size: calc(var(--horizontal-icon) * 0.64);
       line-height: 1;
       background: radial-gradient(circle at 35% 35%, rgba(56, 189, 248, 0.65), rgba(56, 189, 248, 0.08) 70%, rgba(15, 23, 42, 0));
       box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
@@ -130,26 +130,29 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: clamp(4px, 1vh, 10px);
+      gap: clamp(2px, 0.8vh, 8px);
       text-transform: uppercase;
       letter-spacing: 0.1em;
     }
 
     .xmb-entry__title {
       font-weight: 700;
-      font-size: clamp(0.95rem, 2.8vw, 1.35rem);
+      font-size: clamp(0.85rem, 2.4vw, 1.15rem);
       color: var(--text-primary);
     }
 
     .xmb-entry__subtitle {
-      font-size: clamp(0.7rem, 2vw, 0.95rem);
+      font-size: clamp(0.62rem, 1.8vw, 0.85rem);
       color: var(--text-muted);
       letter-spacing: 0.08em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .xmb-entry.is-active {
       opacity: 1;
-      transform: translateY(-10px) scale(1.08);
+      transform: translateY(-8px) scale(1.04);
     }
 
     .xmb-entry:focus-visible {

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -15,7 +15,7 @@
       --horizontal-band-height: clamp(230px, 36vh, 320px);
       --horizontal-offset: clamp(110px, 22vh, 200px);
       --horizontal-gap: clamp(28px, 6vw, 60px);
-      --horizontal-icon: clamp(48px, 10vw, 96px);
+      --horizontal-icon: clamp(48px, 10vw, 80px);
       --vertical-gap: clamp(22px, 6vh, 36px);
       --vertical-icon: clamp(48px, 10vw, 80px);
       --fade-width: 20%;
@@ -182,12 +182,12 @@
       display: flex;
       align-items: flex-end;
       gap: var(--horizontal-gap);
-      margin-left: 20vw;
+      margin-left: clamp(6vw, 10vw, 14vw);
       transform: translateX(0);
       transition: transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
       will-change: transform;
-      padding-left: clamp(260px, 38vw, 420px);
-      padding-right: clamp(260px, 38vw, 400px);
+      padding-left: clamp(140px, 26vw, 320px);
+      padding-right: clamp(200px, 34vw, 360px);
     }
 
     .xmb-year {
@@ -284,7 +284,7 @@
       :root {
         --horizontal-band-height: clamp(220px, 42vh, 320px);
         --horizontal-gap: clamp(24px, 9vw, 44px);
-        --horizontal-icon: clamp(44px, 12vw, 68px);
+        --horizontal-icon: clamp(40px, 11vw, 64px);
         --vertical-gap: clamp(14px, 4vh, 24px);
         --vertical-icon: clamp(40px, 11vw, 64px);
         --vertical-offset: clamp(28px, 8vw, 72px);

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -62,6 +62,71 @@
     return limitWords(event.year, 8);
   }
 
+  function formatOrdinal(value) {
+    const absValue = Math.abs(value);
+    const mod100 = absValue % 100;
+    if (mod100 >= 11 && mod100 <= 13) {
+      return `${value}th`;
+    }
+    switch (absValue % 10) {
+      case 1:
+        return `${value}st`;
+      case 2:
+        return `${value}nd`;
+      case 3:
+        return `${value}rd`;
+      default:
+        return `${value}th`;
+    }
+  }
+
+  function formatYearLabel(event, fallbackLabel) {
+    const fallback = (fallbackLabel || event?.year || '').trim() || 'Undated';
+    if (!event) {
+      return fallback;
+    }
+
+    const raw = (event.year || '').trim();
+    if (/^\d{4}$/.test(raw)) {
+      return raw;
+    }
+
+    const centuryMatch = raw.match(/(\d+)(?:st|nd|rd|th)?\s*century/i);
+    if (centuryMatch) {
+      const centuryNumber = parseInt(centuryMatch[1], 10);
+      if (Number.isFinite(centuryNumber)) {
+        return `${formatOrdinal(centuryNumber)} century`;
+      }
+    }
+
+    const value = Number.isFinite(event.yearValue) ? event.yearValue : Number.NaN;
+
+    if (raw.toLowerCase().includes('century') && Number.isFinite(value)) {
+      const inferredCentury = Math.ceil(value / 100);
+      if (inferredCentury >= 1) {
+        return `${formatOrdinal(inferredCentury)} century`;
+      }
+    }
+
+    if (Number.isFinite(value)) {
+      const decade = Math.floor(value / 10) * 10;
+      const padded = decade.toString().padStart(4, '0');
+      return `${padded}'s`;
+    }
+
+    const explicitYear = raw.match(/(\d{4})/);
+    if (explicitYear) {
+      return explicitYear[1];
+    }
+
+    const decadeMatch = raw.match(/(\d{3})/);
+    if (decadeMatch) {
+      return `${decadeMatch[1]}0's`;
+    }
+
+    return fallback;
+  }
+
   function buildYearGroups(data) {
     if (!Array.isArray(data?.centuries)) {
       return [];
@@ -101,12 +166,12 @@
 
     const ordered = Array.from(groups.values());
     ordered.sort((a, b) => {
-      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.POSITIVE_INFINITY;
-      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.POSITIVE_INFINITY;
+      const aValue = Number.isFinite(a.sortValue) ? a.sortValue : Number.NEGATIVE_INFINITY;
+      const bValue = Number.isFinite(b.sortValue) ? b.sortValue : Number.NEGATIVE_INFINITY;
       if (aValue !== bValue) {
-        return aValue - bValue;
+        return bValue - aValue;
       }
-      return a.label.localeCompare(b.label, undefined, { numeric: true });
+      return b.label.localeCompare(a.label, undefined, { numeric: true });
     });
 
     ordered.forEach((group, index) => {
@@ -119,10 +184,11 @@
         return a.eventIndex - b.eventIndex;
       });
       const primaryEventWithIcon = group.events.find(entry => entry.event.icon);
-      const primaryEvent = group.events[0]?.event;
+      const representativeEvent = group.events.find(entry => Number.isFinite(entry.event.yearValue))?.event
+        || group.events[0]?.event;
       group.icon = primaryEventWithIcon?.event?.icon || '🕰️';
-      group.yearLabel = limitWords(primaryEvent?.year || group.label, 3) || `Year ${index + 1}`;
-      group.subtitle = getYearSubtitle(group);
+      group.yearLabel = formatYearLabel(representativeEvent, group.label) || `Year ${index + 1}`;
+      group.subtitle = '';
     });
 
     return ordered;
@@ -322,13 +388,6 @@
       title.className = 'xmb-year__title';
       title.textContent = group.yearLabel;
       copy.appendChild(title);
-
-      if (group.subtitle) {
-        const subtitle = document.createElement('span');
-        subtitle.className = 'xmb-year__subtitle';
-        subtitle.textContent = group.subtitle;
-        copy.appendChild(subtitle);
-      }
 
       button.appendChild(copy);
 

--- a/static/bpvsbuckler/timeline.js
+++ b/static/bpvsbuckler/timeline.js
@@ -40,6 +40,23 @@
     return words.slice(0, Math.max(1, maxWords)).join(' ');
   }
 
+  function limitCharacters(value, maxChars) {
+    if (!value) {
+      return '';
+    }
+    const trimmed = String(value).trim();
+    if (!Number.isFinite(maxChars) || maxChars <= 0 || trimmed.length <= maxChars) {
+      return trimmed;
+    }
+
+    const shortened = trimmed.slice(0, maxChars);
+    const withoutDangling = shortened.replace(/\s+\S*$/, '');
+    if (withoutDangling.length >= Math.max(3, Math.floor(maxChars * 0.6))) {
+      return withoutDangling;
+    }
+    return shortened.slice(0, Math.max(1, maxChars - 1));
+  }
+
   function getYearSubtitle(group) {
     if (!group || !group.events.length) {
       return '';
@@ -49,17 +66,17 @@
     return limitWords(subtitleSource, 6);
   }
 
-  function getEventSubtitle(event) {
+  function getEventSubtitle(event, maxChars) {
     if (!event) {
       return '';
     }
     if (event.summary) {
-      return limitWords(event.summary, 8);
+      return limitCharacters(limitWords(event.summary, 8), maxChars);
     }
     if (event.title) {
-      return limitWords(event.title, 8);
+      return limitCharacters(limitWords(event.title, 8), maxChars);
     }
-    return limitWords(event.year, 8);
+    return limitCharacters(limitWords(event.year, 8), maxChars);
   }
 
   function formatOrdinal(value) {
@@ -330,14 +347,18 @@
 
       const title = document.createElement('span');
       title.className = 'xmb-entry__title';
-      title.textContent = limitWords(event.iconLabel || event.title || event.year || 'Entry', 6);
+      const titleText = limitWords(event.iconLabel || event.title || event.year || 'Entry', 2);
+      title.textContent = titleText;
       copy.appendChild(title);
 
-      const subtitleText = getEventSubtitle(event);
+      const normalizedTitleLength = titleText.replace(/\s+/g, '').length;
+      const maxSubtitleChars = Math.max(12, Math.round(normalizedTitleLength * 1.8));
+      const subtitleText = getEventSubtitle(event, maxSubtitleChars);
       if (subtitleText) {
         const subtitle = document.createElement('span');
         subtitle.className = 'xmb-entry__subtitle';
         subtitle.textContent = subtitleText;
+        subtitle.title = subtitleText;
         copy.appendChild(subtitle);
       }
 
@@ -360,6 +381,7 @@
     entryTrack.appendChild(fragment);
     entryCards = Array.from(entryTrack.querySelectorAll('.xmb-entry'));
     setActiveEntry(0, { focus: false });
+    requestAnimationFrame(updateEntrySubtitleWidths);
   }
 
   function renderYearButtons(groups) {
@@ -437,6 +459,25 @@
     alignYearList();
   }
 
+  function updateEntrySubtitleWidths() {
+    if (!entryCards.length) {
+      return;
+    }
+    entryCards.forEach(card => {
+      const title = card.querySelector('.xmb-entry__title');
+      const subtitle = card.querySelector('.xmb-entry__subtitle');
+      if (!title || !subtitle) {
+        return;
+      }
+      subtitle.style.maxWidth = '';
+      const rect = title.getBoundingClientRect();
+      const width = rect?.width;
+      if (Number.isFinite(width) && width > 0) {
+        subtitle.style.maxWidth = `${Math.ceil(width)}px`;
+      }
+    });
+  }
+
   function handleKeydown(event) {
     if (event.altKey || event.ctrlKey || event.metaKey) {
       return;
@@ -512,6 +553,7 @@
     requestAnimationFrame(() => {
       alignYearList();
       alignEntryTrack();
+      updateEntrySubtitleWidths();
     });
   }
 


### PR DESCRIPTION
## Summary
- match the horizontal entry icon sizing with the vertical menu icons
- reduce the left offset of the horizontal track so entries sit closer to the year list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f5163bb5c483209ffa31c19e945013