### PR TITLE
Add background video to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,12 @@ body{color:#202020}
 </script>
 <!-- google tracking code end -->
 </head>
-<body style="background-color:#333666;background:#333666;" data-role="page" onload="pageLoad()">
-	<header id="mainWrapper">
+<body class="has-background-video" style="background-color:#333666;background:#333666;" data-role="page" onload="pageLoad()">
+        <video id="background-video" autoplay loop muted playsinline>
+                <source src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4">
+                Your browser does not support the background video.
+        </video>
+        <header id="mainWrapper">
 		<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 			 <h1 class="v-h">Site Navigation</h1>
                          <a data-content="DATRO" href="index.html" title="DATRO">
@@ -144,7 +148,7 @@ body{color:#202020}
 		<div class="loader-section section-left"></div>
 		<div class="loader-section section-right"></div>
 	</div>
-	<main style="background-color: #333366;">
+        <main style="background-color: rgba(51, 51, 102, 0.85);">
 		<div class="carousel" data-ride="carousel" id="myCarousel">
 			<div class="carousel-inner" style="overflow:visible!important;">
 				<div class="carousel-item active">

--- a/static/datro/css/style.css
+++ b/static/datro/css/style.css
@@ -150,13 +150,60 @@ v:after{
 	line-height:1px!important
 }
 .copyleft-1{
-	font-size:40%;
-	color:#fff;
-	margin:18px auto 0 auto;
-	position:relative;
-	text-align:center;
-	vertical-align:text-top;
-	opacity:.8
+        font-size:40%;
+        color:#fff;
+        margin:18px auto 0 auto;
+        position:relative;
+        text-align:center;
+        vertical-align:text-top;
+        opacity:.8
+}
+
+.has-background-video{
+        position:relative;
+}
+
+.has-background-video::before{
+        content:"";
+        position:fixed;
+        top:0;
+        left:0;
+        width:100%;
+        height:100%;
+        background:rgba(14,12,36,.55);
+        z-index:-1;
+}
+
+#background-video{
+        position:fixed;
+        top:50%;
+        left:50%;
+        min-width:100%;
+        min-height:100%;
+        width:auto;
+        height:auto;
+        transform:translate(-50%,-50%);
+        object-fit:cover;
+        z-index:-2;
+        background-color:#333666;
+}
+
+@media (max-width:767px){
+        #background-video{
+                display:none;
+        }
+        .has-background-video::before{
+                background:#333666;
+        }
+}
+
+@media (prefers-reduced-motion:reduce){
+        #background-video{
+                display:none;
+        }
+        .has-background-video::before{
+                background:#333666;
+        }
 }
 .navbar-brand{
 	image-rendering:auto;


### PR DESCRIPTION
## Summary
- embed the DATRO timeline video as a looping background on the landing page
- add supporting styles and overlay treatment so content stays readable
- adjust the main container background to allow the video to show through

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68f5aa880d7c8320acdc337f2272714c