### PR TITLE
Add background video to timeline page

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -9,6 +9,7 @@
     :root {
       color-scheme: dark;
       --page-background: #000000;
+      --surface-overlay: rgba(2, 6, 23, 0.76);
       --text-primary: #f8fafc;
       --text-muted: rgba(226, 232, 240, 0.6);
       --accent: #38bdf8;
@@ -37,6 +38,28 @@
       overflow: hidden;
     }
 
+    .background-video-container {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .background-video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: saturate(1.05) contrast(1.05) brightness(0.95);
+    }
+
+    .background-video__overlay {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 20%, rgba(15, 118, 226, 0.22), rgba(2, 6, 23, 0.65) 55%),
+        linear-gradient(180deg, rgba(2, 6, 23, 0.55) 0%, rgba(2, 6, 23, 0.88) 75%);
+    }
+
     a {
       color: inherit;
       text-decoration: none;
@@ -51,8 +74,9 @@
       min-height: 100vh;
       display: flex;
       flex-direction: column;
-      background: var(--page-background);
+      background: var(--surface-overlay);
       isolation: isolate;
+      backdrop-filter: blur(18px);
     }
 
     .xmb-stage {
@@ -332,6 +356,13 @@
   </style>
 </head>
 <body>
+  <div class="background-video-container" aria-hidden="true">
+    <video class="background-video" autoplay muted loop playsinline>
+      <source src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4" />
+      Your browser does not support the background video.
+    </video>
+    <div class="background-video__overlay"></div>
+  </div>
   <div class="xmb-shell">
     <main class="xmb-stage">
       <section class="xmb-vertical" aria-label="Timeline years">


### PR DESCRIPTION
## Summary
- embed the provided hosted MP4 as a looping background video on the /static/bpvsbuckler timeline page
- add overlay styling and blur so the new motion background supports legibility of foreground content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f681e26e608320a4b04d37c855c495