### PR TITLE
Fix timeline background video stacking order

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Great House Farm Timeline</title>
+  <link rel="preload" as="video" href="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4">
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
@@ -365,9 +366,8 @@
       loop
       playsinline
       preload="auto"
-      crossorigin="anonymous"
+      data-video-src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
     >
-      <source src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4" />
       Your browser does not support the background video.
     </video>
     <div class="background-video__overlay"></div>
@@ -377,6 +377,24 @@
     document.addEventListener("DOMContentLoaded", () => {
       const video = document.querySelector(".background-video");
       if (!video) return;
+
+      const baseSource = video.getAttribute("data-video-src");
+      if (!baseSource) return;
+
+      const setSource = (nextSrc) => {
+        if (video.src !== nextSrc) {
+          video.src = nextSrc;
+        }
+      };
+
+      let retryCount = 0;
+      const maxRetryDelay = 4000;
+
+      const buildSrc = () => {
+        if (!retryCount) return baseSource;
+        const retryToken = Date.now();
+        return `${baseSource}?retry=${retryCount}-${retryToken}`;
+      };
 
       const ensureAttributes = () => {
         video.muted = true;
@@ -391,10 +409,13 @@
 
       const tryPlay = () => {
         ensureAttributes();
+        if (!video.src) {
+          setSource(buildSrc());
+        }
+
         const playAttempt = video.play();
         if (playAttempt && typeof playAttempt.then === "function") {
           playAttempt.catch(() => {
-            video.load();
             requestAnimationFrame(() => {
               const retryAttempt = video.play();
               if (retryAttempt && typeof retryAttempt.then === "function") {
@@ -420,10 +441,17 @@
         video.addEventListener("loadeddata", onCanPlay);
         video.addEventListener("loadedmetadata", onCanPlay);
         video.addEventListener("error", () => {
+          retryCount += 1;
+          const retryDelay = Math.min(maxRetryDelay, 600 * retryCount);
           setTimeout(() => {
-            video.load();
-          }, 1200);
+            setSource(buildSrc());
+            tryPlay();
+          }, retryDelay);
         });
+      }
+
+      if (!video.src) {
+        setSource(baseSource);
       }
 
       requestAnimationFrame(tryPlay);
@@ -441,6 +469,7 @@
       });
 
       video.addEventListener("playing", () => {
+        retryCount = 0;
         video.controls = false;
       });
 

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -358,12 +358,99 @@
 </head>
 <body>
   <div class="background-video-container" aria-hidden="true">
-    <video class="background-video" autoplay muted loop playsinline preload="auto">
+    <video
+      class="background-video"
+      autoplay
+      muted
+      loop
+      playsinline
+      preload="auto"
+      crossorigin="anonymous"
+    >
       <source src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4" />
       Your browser does not support the background video.
     </video>
     <div class="background-video__overlay"></div>
   </div>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const video = document.querySelector(".background-video");
+      if (!video) return;
+
+      const ensureAttributes = () => {
+        video.muted = true;
+        video.defaultMuted = true;
+        video.loop = true;
+        video.playsInline = true;
+        video.controls = false;
+        video.setAttribute("muted", "");
+        video.setAttribute("playsinline", "");
+        video.setAttribute("autoplay", "");
+      };
+
+      const tryPlay = () => {
+        ensureAttributes();
+        const playAttempt = video.play();
+        if (playAttempt && typeof playAttempt.then === "function") {
+          playAttempt.catch(() => {
+            video.load();
+            requestAnimationFrame(() => {
+              const retryAttempt = video.play();
+              if (retryAttempt && typeof retryAttempt.then === "function") {
+                retryAttempt.catch(() => {
+                  video.controls = true;
+                });
+              }
+            });
+          });
+        }
+      };
+
+      if (video.readyState >= 2) {
+        tryPlay();
+      } else {
+        const onCanPlay = () => {
+          video.removeEventListener("canplay", onCanPlay);
+          video.removeEventListener("loadeddata", onCanPlay);
+          video.removeEventListener("loadedmetadata", onCanPlay);
+          tryPlay();
+        };
+        video.addEventListener("canplay", onCanPlay);
+        video.addEventListener("loadeddata", onCanPlay);
+        video.addEventListener("loadedmetadata", onCanPlay);
+        video.addEventListener("error", () => {
+          setTimeout(() => {
+            video.load();
+          }, 1200);
+        });
+      }
+
+      requestAnimationFrame(tryPlay);
+
+      video.addEventListener("pause", () => {
+        if (!video.seeking && !document.hidden) {
+          tryPlay();
+        }
+      });
+
+      ["waiting", "stalled"].forEach((eventName) => {
+        video.addEventListener(eventName, () => {
+          tryPlay();
+        });
+      });
+
+      video.addEventListener("playing", () => {
+        video.controls = false;
+      });
+
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) {
+          tryPlay();
+        }
+      });
+    });
+  </script>
   <div class="xmb-shell">
     <main class="xmb-stage">
       <section class="xmb-vertical" aria-label="Timeline years">

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -9,6 +9,7 @@
     :root {
       color-scheme: dark;
       --page-background: #000000;
+      --surface-overlay: rgba(2, 6, 23, 0.76);
       --text-primary: #f8fafc;
       --text-muted: rgba(226, 232, 240, 0.6);
       --accent: #38bdf8;
@@ -37,6 +38,28 @@
       overflow: hidden;
     }
 
+    .background-video-container {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .background-video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: saturate(1.05) contrast(1.05) brightness(0.95);
+    }
+
+    .background-video__overlay {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 20%, rgba(15, 118, 226, 0.22), rgba(2, 6, 23, 0.65) 55%),
+        linear-gradient(180deg, rgba(2, 6, 23, 0.55) 0%, rgba(2, 6, 23, 0.88) 75%);
+    }
+
     a {
       color: inherit;
       text-decoration: none;
@@ -48,11 +71,13 @@
 
     .xmb-shell {
       position: relative;
+      z-index: 1;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
-      background: var(--page-background);
+      background: var(--surface-overlay);
       isolation: isolate;
+      backdrop-filter: blur(18px);
     }
 
     .xmb-stage {
@@ -332,6 +357,13 @@
   </style>
 </head>
 <body>
+  <div class="background-video-container" aria-hidden="true">
+    <video class="background-video" autoplay muted loop playsinline preload="auto">
+      <source src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4" />
+      Your browser does not support the background video.
+    </video>
+    <div class="background-video__overlay"></div>
+  </div>
   <div class="xmb-shell">
     <main class="xmb-stage">
       <section class="xmb-vertical" aria-label="Timeline years">


### PR DESCRIPTION
## Summary
- ensure the background video container renders above the page backdrop while keeping foreground content elevated
- preload the background video so playback begins as soon as the page loads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f681e26e608320a4b04d37c855c495