### PR TITLE
Remove Netlify embed from BPVSBuckler page

### DIFF
--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -366,8 +366,13 @@
       loop
       playsinline
       preload="auto"
+      src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
       data-video-src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
     >
+      <source
+        src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
+        type="video/mp4"
+      />
       Your browser does not support the background video.
     </video>
     <div class="background-video__overlay"></div>
@@ -378,12 +383,21 @@
       const video = document.querySelector(".background-video");
       if (!video) return;
 
-      const baseSource = video.getAttribute("data-video-src");
+      const baseSource =
+        video.getAttribute("data-video-src") ||
+        video.currentSrc ||
+        video.getAttribute("src");
       if (!baseSource) return;
+
+      const sourceEl = video.querySelector("source");
 
       const setSource = (nextSrc) => {
         if (video.src !== nextSrc) {
           video.src = nextSrc;
+        }
+        if (sourceEl && sourceEl.src !== nextSrc) {
+          sourceEl.src = nextSrc;
+          sourceEl.setAttribute("src", nextSrc);
         }
       };
 

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -4,7 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Great House Farm Timeline</title>
-  <link rel="preload" as="video" href="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4" type="video/mp4">
+  <link
+    rel="preload"
+    as="video"
+    href="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
+    type="video/mp4"
+    crossorigin="anonymous"
+  >
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
@@ -42,16 +48,19 @@
     .background-video-container {
       position: fixed;
       inset: 0;
-      z-index: 0;
+      z-index: 1;
       overflow: hidden;
       pointer-events: none;
     }
 
     .background-video {
+      position: absolute;
+      inset: 0;
       width: 100%;
       height: 100%;
       object-fit: cover;
       filter: saturate(1.05) contrast(1.05) brightness(0.95);
+      z-index: 1;
     }
 
     .background-video__overlay {
@@ -59,6 +68,8 @@
       inset: 0;
       background: radial-gradient(circle at 30% 20%, rgba(15, 118, 226, 0.22), rgba(2, 6, 23, 0.65) 55%),
         linear-gradient(180deg, rgba(2, 6, 23, 0.55) 0%, rgba(2, 6, 23, 0.88) 75%);
+      z-index: 2;
+      pointer-events: none;
     }
 
     a {
@@ -72,7 +83,7 @@
 
     .xmb-shell {
       position: relative;
-      z-index: 1;
+      z-index: 3;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -196,7 +207,7 @@
       align-items: flex-end;
       padding-bottom: clamp(24px, 6vh, 40px);
       background: transparent;
-      z-index: 3;
+      z-index: 4;
     }
 
     .xmb-horizontal__viewport {
@@ -288,7 +299,7 @@
       width: var(--fade-width);
       background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 90%);
       pointer-events: none;
-      z-index: 4;
+      z-index: 5;
     }
 
     .xmb-loading {
@@ -302,7 +313,7 @@
       color: var(--text-muted);
       font-size: 0.95rem;
       box-shadow: 0 18px 48px rgba(2, 6, 23, 0.6);
-      z-index: 5;
+      z-index: 6;
     }
 
     .xmb-loading.is-hidden {
@@ -368,10 +379,12 @@
       preload="auto"
       src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
       data-video-src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
+      crossorigin="anonymous"
     >
       <source
         src="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
         type="video/mp4"
+        crossorigin="anonymous"
       />
       Your browser does not support the background video.
     </video>
@@ -390,6 +403,16 @@
       if (!baseSource) return;
 
       const sourceEl = video.querySelector("source");
+
+      const ensureCrossOrigin = () => {
+        video.crossOrigin = "anonymous";
+        video.setAttribute("crossorigin", "anonymous");
+        if (sourceEl) {
+          sourceEl.setAttribute("crossorigin", "anonymous");
+        }
+      };
+
+      ensureCrossOrigin();
 
       const setSource = (nextSrc) => {
         if (video.src !== nextSrc) {
@@ -411,6 +434,7 @@
       };
 
       const ensureAttributes = () => {
+        ensureCrossOrigin();
         video.muted = true;
         video.defaultMuted = true;
         video.loop = true;

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -500,18 +500,5 @@
   </div>
 
   <script src="timeline.js"></script>
-<div data-netlify-deploy-id="68f0642b66127200088703cf" data-netlify-site-id="e7130a7c-7fa0-41b7-be06-ed9d819853e6" data-vcs="github" style="position:fixed">
-  <script>
-    (function () {
-      var host = window.location && window.location.hostname;
-      if (!host || host === "localhost" || host === "127.0.0.1" || host === "[::1]") {
-        return;
-      }
-      var script = document.createElement("script");
-      script.async = true;
-      script.src = "/.netlify/scripts/cdp";
-      document.currentScript.parentNode.appendChild(script);
-    })();
-  </script>
-</div></body>
+</body>
 </html>

--- a/static/bpvsbuckler/index.html
+++ b/static/bpvsbuckler/index.html
@@ -6,7 +6,7 @@
   <title>Great House Farm Timeline</title>
   <link
     rel="preload"
-    as="video"
+    as="fetch"
     href="https://wayback.datro.xyz/2025-10-19_timeline-background_video_v0.0.1.mp4"
     type="video/mp4"
     crossorigin="anonymous"
@@ -48,7 +48,7 @@
     .background-video-container {
       position: fixed;
       inset: 0;
-      z-index: 1;
+      z-index: 0;
       overflow: hidden;
       pointer-events: none;
     }
@@ -60,7 +60,7 @@
       height: 100%;
       object-fit: cover;
       filter: saturate(1.05) contrast(1.05) brightness(0.95);
-      z-index: 1;
+      z-index: 0;
     }
 
     .background-video__overlay {
@@ -68,7 +68,7 @@
       inset: 0;
       background: radial-gradient(circle at 30% 20%, rgba(15, 118, 226, 0.22), rgba(2, 6, 23, 0.65) 55%),
         linear-gradient(180deg, rgba(2, 6, 23, 0.55) 0%, rgba(2, 6, 23, 0.88) 75%);
-      z-index: 2;
+      z-index: 1;
       pointer-events: none;
     }
 
@@ -83,7 +83,7 @@
 
     .xmb-shell {
       position: relative;
-      z-index: 3;
+      z-index: 2;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -207,7 +207,7 @@
       align-items: flex-end;
       padding-bottom: clamp(24px, 6vh, 40px);
       background: transparent;
-      z-index: 4;
+      z-index: 3;
     }
 
     .xmb-horizontal__viewport {
@@ -216,6 +216,22 @@
       padding-left: clamp(16px, 3vw, 28px);
       padding-right: clamp(24px, 5vw, 48px);
       position: relative;
+      mask-image: linear-gradient(
+        90deg,
+        rgba(0, 0, 0, 1) 0%,
+        rgba(0, 0, 0, 1) calc(100% - var(--fade-width)),
+        rgba(0, 0, 0, 0) 100%
+      );
+      -webkit-mask-image: linear-gradient(
+        90deg,
+        rgba(0, 0, 0, 1) 0%,
+        rgba(0, 0, 0, 1) calc(100% - var(--fade-width)),
+        rgba(0, 0, 0, 0) 100%
+      );
+      mask-size: 100% 100%;
+      -webkit-mask-size: 100% 100%;
+      mask-repeat: no-repeat;
+      -webkit-mask-repeat: no-repeat;
     }
 
     .xmb-horizontal__track {
@@ -289,17 +305,6 @@
     .xmb-year:focus-visible {
       outline: 3px solid var(--accent);
       outline-offset: 5px;
-    }
-
-    .xmb-horizontal__fade {
-      position: absolute;
-      top: clamp(12px, 3vh, 24px);
-      bottom: clamp(12px, 3vh, 24px);
-      right: 0;
-      width: var(--fade-width);
-      background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 90%);
-      pointer-events: none;
-      z-index: 5;
     }
 
     .xmb-loading {
@@ -530,7 +535,6 @@
     <nav class="xmb-horizontal" aria-label="Timeline entries">
       <div class="xmb-horizontal__viewport" id="entry-bar-viewport">
         <div class="xmb-horizontal__track" id="timeline-entry-track" role="listbox" aria-label="Timeline entries"></div>
-        <div class="xmb-horizontal__fade" aria-hidden="true"></div>
       </div>
     </nav>
 


### PR DESCRIPTION
## Summary
- remove the Netlify deploy badge container and script from the BPVSBuckler index page
- ensure the page now closes cleanly without loading Netlify-hosted assets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f6915c69108320a71a989238941686