### PR TITLE
Refine projections UI without Tailwind runtime

### DIFF
--- a/static/projections/index.html
+++ b/static/projections/index.html
@@ -427,8 +427,7 @@
     const updateSliderForIndex = (index) => {
       const frame = battleshipData[index];
       if (!frame) return;
-      const sliderPosition = sliderMaxIndex - index;
-      slider.value = String(sliderPosition);
+      slider.value = String(index);
       slider.setAttribute('aria-valuenow', String(frame.year));
       slider.setAttribute('aria-valuetext', frame.label);
     };
@@ -449,8 +448,7 @@
       const sliderValue = Number(event.target.value);
       if (!Number.isFinite(sliderValue)) return;
       const constrainedValue = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
-      const dataIndex = sliderMaxIndex - constrainedValue;
-      renderFrame(dataIndex);
+      renderFrame(constrainedValue);
     });
 
     const initialize = async () => {
@@ -486,7 +484,7 @@
         sliderMaxIndex = battleshipData.length - 1;
         slider.max = String(sliderMaxIndex);
         slider.step = '1';
-        slider.value = String(sliderMaxIndex);
+        slider.value = '0';
         slider.setAttribute('aria-valuemin', String(battleshipData[0].year));
         slider.setAttribute('aria-valuemax', String(battleshipData[sliderMaxIndex].year));
         sliderEnd.textContent = battleshipData[0].year;

--- a/static/projections/index.html
+++ b/static/projections/index.html
@@ -424,13 +424,20 @@
       });
     };
 
+    const updateSliderForIndex = (index) => {
+      const frame = battleshipData[index];
+      if (!frame) return;
+      const sliderPosition = sliderMaxIndex - index;
+      slider.value = String(sliderPosition);
+      slider.setAttribute('aria-valuenow', String(frame.year));
+      slider.setAttribute('aria-valuetext', frame.label);
+    };
+
     const renderFrame = (index) => {
       const frame = battleshipData[index];
       if (!frame) return;
-      slider.value = String(index);
+      updateSliderForIndex(index);
       yearLabel.textContent = frame.label;
-      slider.setAttribute('aria-valuetext', frame.label);
-      slider.setAttribute('aria-valuenow', String(frame.year));
       renderQuadrant('income', frame.income);
       renderQuadrant('assets', frame.assets);
       renderQuadrant('liabilities', frame.liabilities);
@@ -442,7 +449,8 @@
       const sliderValue = Number(event.target.value);
       if (!Number.isFinite(sliderValue)) return;
       const constrainedValue = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
-      renderFrame(constrainedValue);
+      const dataIndex = sliderMaxIndex - constrainedValue;
+      renderFrame(dataIndex);
     });
 
     const initialize = async () => {
@@ -474,15 +482,13 @@
         }
 
         slider.disabled = false;
-        slider.min = 0;
+        slider.min = '0';
         sliderMaxIndex = battleshipData.length - 1;
-        slider.max = sliderMaxIndex;
-        slider.step = 1;
-        slider.value = '0';
+        slider.max = String(sliderMaxIndex);
+        slider.step = '1';
+        slider.value = String(sliderMaxIndex);
         slider.setAttribute('aria-valuemin', String(battleshipData[0].year));
         slider.setAttribute('aria-valuemax', String(battleshipData[sliderMaxIndex].year));
-        slider.setAttribute('aria-valuenow', String(battleshipData[0].year));
-        slider.setAttribute('aria-valuetext', battleshipData[0].label);
         sliderEnd.textContent = battleshipData[0].year;
         sliderStart.textContent = battleshipData[sliderMaxIndex].year;
         renderFrame(0);

--- a/static/projections/index.html
+++ b/static/projections/index.html
@@ -427,7 +427,8 @@
     const updateSliderForIndex = (index) => {
       const frame = battleshipData[index];
       if (!frame) return;
-      slider.value = String(index);
+      const sliderPosition = sliderMaxIndex - index;
+      slider.value = String(sliderPosition);
       slider.setAttribute('aria-valuenow', String(frame.year));
       slider.setAttribute('aria-valuetext', frame.label);
     };
@@ -448,7 +449,8 @@
       const sliderValue = Number(event.target.value);
       if (!Number.isFinite(sliderValue)) return;
       const constrainedValue = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
-      renderFrame(constrainedValue);
+      const frameIndex = sliderMaxIndex - constrainedValue;
+      renderFrame(frameIndex);
     });
 
     const initialize = async () => {
@@ -484,7 +486,7 @@
         sliderMaxIndex = battleshipData.length - 1;
         slider.max = String(sliderMaxIndex);
         slider.step = '1';
-        slider.value = '0';
+        slider.value = String(sliderMaxIndex);
         slider.setAttribute('aria-valuemin', String(battleshipData[0].year));
         slider.setAttribute('aria-valuemax', String(battleshipData[sliderMaxIndex].year));
         sliderEnd.textContent = battleshipData[0].year;

--- a/static/projections/index.html
+++ b/static/projections/index.html
@@ -4,88 +4,119 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Financial Model</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    html {
-      scroll-behavior: smooth;
-    }
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(10px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    .animate-fade-in {
-      animation: fadeIn 0.5s ease-out forwards;
-    }
-  </style>
+  <link rel="stylesheet" href="projections.css" />
 </head>
-<body class="bg-slate-900 text-slate-300 font-sans antialiased min-h-screen flex items-center justify-center p-2 sm:p-4">
-  <main class="bg-slate-800 p-2 sm:p-4 rounded-lg shadow-lg ring-1 ring-white/10 flex gap-4 w-full max-w-7xl h-[90vh]">
-    <div class="flex flex-col items-center justify-center w-16 py-4">
-      <span id="slider-end" class="text-xs text-slate-400 font-semibold transform -rotate-90 origin-center whitespace-nowrap"></span>
+<body class="page-body">
+  <div
+    id="loading-bar-container"
+    class="loading-bar"
+    role="status"
+    aria-live="polite"
+    data-hidden="true"
+  >
+    <div id="loading-bar" class="loading-bar__progress"></div>
+  </div>
+  <main class="dashboard">
+    <aside class="slider-column">
+      <span id="slider-end" class="slider-label"></span>
       <input
         id="year-slider"
+        class="year-slider"
         type="range"
         min="0"
         step="1"
         value="0"
-        class="flex-grow w-2 h-full bg-slate-700 rounded-lg appearance-none cursor-pointer my-4"
-        style="writing-mode: vertical-lr;"
         aria-orientation="vertical"
         aria-label="Financial Year Slider"
       />
-      <span id="slider-start" class="text-xs text-slate-400 font-semibold transform -rotate-90 origin-center whitespace-nowrap"></span>
-    </div>
+      <span id="slider-start" class="slider-label"></span>
+    </aside>
 
-    <div class="flex-grow min-w-0 flex flex-col">
-      <div class="text-center mb-2">
-        <h3 id="year-label" class="text-lg font-bold text-amber-400"></h3>
+    <section class="content-column">
+      <header class="year-header">
+        <h3 id="year-label" class="year-title">Loading projections…</h3>
+      </header>
+
+      <div class="row-group" data-row-group="top" data-expanded="false">
+        <div class="panel-grid">
+          <section class="panel" data-quadrant="income">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <div class="panel-header">
+                <h4 class="panel-title">Lenders / Financing Summary</h4>
+                <p class="panel-total" data-total>$0</p>
+              </div>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
+
+          <section class="panel" data-quadrant="assets">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <div class="panel-header">
+                <h4 class="panel-title">Assets (Owned Value)</h4>
+                <p class="panel-total" data-total>$0</p>
+              </div>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
+        </div>
+        <button
+          type="button"
+          class="row-toggle"
+          data-row-toggle
+          aria-expanded="false"
+          title="Expand row"
+        >
+          <span aria-hidden="true" class="row-toggle-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="20" height="20">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
+            </svg>
+          </span>
+          <span class="sr-only" data-toggle-label>Expand row</span>
+        </button>
       </div>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-4 flex-grow overflow-hidden">
-        <section class="relative p-3 rounded-lg flex flex-col bg-emerald-900/70 overflow-hidden" data-quadrant="income">
-          <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-          <div class="relative z-10 flex-grow flex flex-col min-h-0">
-            <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-              <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Lenders / Income (Interest payments)</h4>
-              <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-            </div>
-            <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-          </div>
-        </section>
 
-        <section class="relative p-3 rounded-lg flex flex-col bg-sky-900/70 overflow-hidden" data-quadrant="assets">
-          <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-          <div class="relative z-10 flex-grow flex flex-col min-h-0">
-            <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-              <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Assets (Owned Value)</h4>
-              <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
+      <div class="row-group" data-row-group="bottom" data-expanded="false">
+        <div class="panel-grid">
+          <section class="panel" data-quadrant="liabilities">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <div class="panel-header">
+                <h4 class="panel-title">Liabilities (Owed Value)</h4>
+                <p class="panel-total" data-total>$0</p>
+              </div>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
             </div>
-            <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-          </div>
-        </section>
+          </section>
 
-        <section class="relative p-3 rounded-lg flex flex-col bg-indigo-900/70 overflow-hidden" data-quadrant="liabilities">
-          <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-          <div class="relative z-10 flex-grow flex flex-col min-h-0">
-            <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-              <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Liabilities (Owed Value)</h4>
-              <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
+          <section class="panel" data-quadrant="expenses">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <div class="panel-header">
+                <h4 class="panel-title">Expenses (Operational &amp; Financing)</h4>
+                <p class="panel-total" data-total>$0</p>
+              </div>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
             </div>
-            <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-          </div>
-        </section>
-
-        <section class="relative p-3 rounded-lg flex flex-col bg-rose-900/70 overflow-hidden" data-quadrant="expenses">
-          <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-          <div class="relative z-10 flex-grow flex flex-col min-h-0">
-            <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-              <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Expenses (Operational &amp; Financing)</h4>
-              <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-            </div>
-            <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-          </div>
-        </section>
+          </section>
+        </div>
+        <button
+          type="button"
+          class="row-toggle"
+          data-row-toggle
+          aria-expanded="false"
+          title="Expand row"
+        >
+          <span aria-hidden="true" class="row-toggle-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="20" height="20">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
+            </svg>
+          </span>
+          <span class="sr-only" data-toggle-label>Expand row</span>
+        </button>
       </div>
-    </div>
+    </section>
   </main>
 
   <script>
@@ -112,6 +143,39 @@
       }).format(value);
     };
 
+    const loadingBarContainer = document.getElementById('loading-bar-container');
+    const loadingBar = document.getElementById('loading-bar');
+    let loadingIntervalId = null;
+    let loadingProgress = 0;
+
+    const startLoadingBar = () => {
+      if (!loadingBarContainer || !loadingBar) return;
+      loadingBarContainer.style.display = 'block';
+      loadingBarContainer.removeAttribute('data-hidden');
+      loadingProgress = 0;
+      loadingBar.style.width = '0%';
+      if (loadingIntervalId) clearInterval(loadingIntervalId);
+      loadingIntervalId = setInterval(() => {
+        loadingProgress = Math.min(loadingProgress + Math.random() * 20 + 5, 90);
+        loadingBar.style.width = `${loadingProgress}%`;
+      }, 200);
+    };
+
+    const finishLoadingBar = () => {
+      if (!loadingBarContainer || !loadingBar) return;
+      if (loadingIntervalId) {
+        clearInterval(loadingIntervalId);
+        loadingIntervalId = null;
+      }
+      loadingBar.style.width = '100%';
+      setTimeout(() => {
+        loadingBarContainer.setAttribute('data-hidden', 'true');
+        setTimeout(() => {
+          loadingBarContainer.style.display = 'none';
+        }, 300);
+      }, 300);
+    };
+
     const createInfoIcon = () => {
       const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
       svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
@@ -119,7 +183,7 @@
       svg.setAttribute('viewBox', '0 0 24 24');
       svg.setAttribute('stroke-width', '2');
       svg.setAttribute('stroke', 'currentColor');
-      svg.setAttribute('class', 'w-4 h-4 text-slate-400 group-hover:text-amber-300 transition-colors');
+      svg.setAttribute('class', 'info-icon');
 
       const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
       path.setAttribute('stroke-linecap', 'round');
@@ -136,24 +200,23 @@
       if (pinCount === 0) return null;
 
       const pinGrid = document.createElement('div');
-      pinGrid.className = 'flex flex-wrap gap-1 p-1 rounded-sm min-h-[1rem]';
-      const pinColor = value >= 0 ? 'bg-white' : 'bg-red-500';
+      pinGrid.className = 'pin-grid';
       const displayCount = Math.min(pinCount, 200);
 
       for (let i = 0; i < displayCount; i += 1) {
         const wrapper = document.createElement('div');
-        wrapper.className = 'w-2 h-2 rounded-full border border-slate-600/50 flex items-center justify-center';
+        wrapper.className = 'pin-cell';
         wrapper.title = '$10,000';
 
         const dot = document.createElement('div');
-        dot.className = `w-full h-full rounded-full ${pinColor} shadow-inner`;
+        dot.className = `pin-dot ${value >= 0 ? 'positive' : 'negative'}`;
         wrapper.appendChild(dot);
         pinGrid.appendChild(wrapper);
       }
 
       if (pinCount > displayCount) {
         const more = document.createElement('div');
-        more.className = 'text-[10px] text-slate-400 self-center ml-1';
+        more.className = 'pin-more';
         more.textContent = `+${pinCount - displayCount} more`;
         pinGrid.appendChild(more);
       }
@@ -163,48 +226,44 @@
 
     const buildShip = (nominal) => {
       const ship = document.createElement('div');
-      ship.className = 'relative group bg-slate-700/50 rounded p-2 my-1 shadow-md ring-1 ring-black/20 animate-fade-in';
+      ship.className = 'entry-card animate-fade-in';
 
       const tooltip = document.createElement('div');
-      tooltip.className = 'absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max max-w-xs px-3 py-1.5 bg-slate-900 text-white text-xs rounded-md shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20';
+      tooltip.className = 'entry-tooltip';
 
       const tooltipTitle = document.createElement('p');
-      tooltipTitle.className = 'font-bold border-b border-slate-600 pb-1 mb-1';
+      tooltipTitle.className = 'entry-tooltip-title';
       tooltipTitle.textContent = `${nominal.code} - ${nominal.description}`;
       tooltip.appendChild(tooltipTitle);
 
       const tooltipValue = document.createElement('p');
-      tooltipValue.className = 'font-bold';
+      tooltipValue.className = 'entry-tooltip-value';
       tooltipValue.textContent = 'Value: ';
       const tooltipValueSpan = document.createElement('span');
-      tooltipValueSpan.className = 'font-mono';
       tooltipValueSpan.textContent = formatCurrencyExact(nominal.value);
       tooltipValue.appendChild(tooltipValueSpan);
       tooltip.appendChild(tooltipValue);
 
-      const tooltipArrow = document.createElement('div');
-      tooltipArrow.className = 'absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-slate-900';
-      tooltip.appendChild(tooltipArrow);
       ship.appendChild(tooltip);
 
       const topRow = document.createElement('div');
-      topRow.className = 'flex justify-between items-start gap-2';
+      topRow.className = 'entry-content';
 
       const textContainer = document.createElement('div');
-      textContainer.className = 'flex-grow';
+      textContainer.className = 'entry-text';
 
       const headingRow = document.createElement('div');
-      headingRow.className = 'flex items-center gap-2';
+      headingRow.className = 'entry-heading';
 
       const title = document.createElement('p');
-      title.className = 'text-xs font-bold text-white uppercase tracking-tighter';
+      title.className = 'entry-title';
       title.textContent = nominal.description;
       headingRow.appendChild(title);
       headingRow.appendChild(createInfoIcon());
       textContainer.appendChild(headingRow);
 
       const valueDisplay = document.createElement('p');
-      valueDisplay.className = 'text-sm font-semibold text-amber-300';
+      valueDisplay.className = 'entry-value';
       valueDisplay.textContent = formatCurrency(nominal.value);
       textContainer.appendChild(valueDisplay);
 
@@ -212,7 +271,7 @@
       ship.appendChild(topRow);
 
       const pinWrapper = document.createElement('div');
-      pinWrapper.className = 'mt-1 bg-slate-800/50 rounded';
+      pinWrapper.className = 'entry-pin-wrapper';
       const pinGrid = createPinGrid(nominal.value);
       if (pinGrid) {
         pinWrapper.appendChild(pinGrid);
@@ -225,7 +284,10 @@
     const parseFinancialData = (csv) => {
       const USD_MULTIPLIER = 1000;
       const START_YEAR = 2024;
-      const lines = csv.split('\n').filter((line) => line.trim() !== '' && !line.toLowerCase().startsWith('code,description'));
+      const lines = csv
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line !== '' && !line.toLowerCase().startsWith('code'));
       const years = [0, 1, 2, 3, 4, 5];
       const labels = years.map((year, index) => {
         const currentYear = START_YEAR + year;
@@ -244,16 +306,17 @@
       lines.forEach((line) => {
         if (line.startsWith('#############')) {
           const header = line.toLowerCase();
-          if (header.includes('lenders / income')) currentQuadrantKey = 'income';
+          if (header.includes('lenders')) currentQuadrantKey = 'income';
+          else if (header.includes('contra-assets')) currentQuadrantKey = 'assets';
           else if (header.includes('assets')) currentQuadrantKey = 'assets';
-          else if (header.includes('liabilities')) currentQuadrantKey = 'liabilities';
+          else if (header.includes('liabilities') || header.includes('equity')) currentQuadrantKey = 'liabilities';
           else if (header.includes('expenses')) currentQuadrantKey = 'expenses';
           return;
         }
 
         if (!currentQuadrantKey) return;
 
-        const parts = line.split(',');
+        const parts = line.split(',').map((part) => part.trim());
         const code = parts[0];
         const description = parts[1];
         const values = parts.slice(2).map((v) => (parseFloat(v) || 0) * USD_MULTIPLIER);
@@ -293,61 +356,21 @@
         return yearEntry;
       });
 
-      if (yearlyData.length > 0) {
-        const totalCapitalFundFromPlan = 5_000_000;
-        const receivablesLine = lines.find((line) => line.includes('Contracts / Receivables'));
-        let totalReceivables = 0;
-        if (receivablesLine) {
-          const values = receivablesLine.split(',').slice(2).map((v) => parseFloat(v) || 0);
-          totalReceivables = values.reduce((sum, val) => sum + val, 0) * USD_MULTIPLIER;
-        }
-
-        const startupFrame = yearlyData[0];
-        const capitalFundNominal = startupFrame.income.nominals.find((n) => n.code === '3200');
-        if (capitalFundNominal) {
-          capitalFundNominal.value = totalCapitalFundFromPlan;
-        }
-
-        const receivablesNominal = startupFrame.assets.nominals.find((n) => n.code === '1300');
-        if (receivablesNominal) {
-          receivablesNominal.value = totalReceivables;
-        }
-
-        startupFrame.income.total = startupFrame.income.nominals.reduce((sum, n) => sum + n.value, 0);
-        startupFrame.assets.total = startupFrame.assets.nominals.reduce((sum, n) => sum + n.value, 0);
-      }
-
       return yearlyData;
     };
 
-    const csvData = `Code,Description,2024,2025,2026,2027,2028,2029
-############# Lenders / Income (Interest payments) #############
-3200,Capital Fund (bond cash in/out incl. interest),1000,800,400,0,0,0
-3400,Interest Received (bank),0,82.5,110,115,120,125
-############# Assets (Owned Value) #############################
-0000,Bank Balance (+),0,200,450,700,950,1200
-1200,Vehicle Values (gross cost),220,830,1350,1680,2200,2600
-1300,Contracts / Receivables,50,210,450,700,950,1200
-############# Liabilities (Owed Value) #########################
-1600,Other (Office, Setup, etc.),-80,-180,-250,-310,-350,-400
-2000,Loan / Bond Payable,-1000,-800,-400,0,0,0
-2100,Accounts Payable,0,-25,-65,-105,-150,-190
-2300,Accumulated Depreciation (Vehicles),0,-110,-260,-430,-640,-870
-2400,Taxes,0,-20,-41,-63,-88,-115
-2500,Other,0,-10,-20,-35,-40,-42
-############# Expenses (Operational & Financing) ###############
-4000,Suppliers & Drivers,0,-120,-175,-220,-310,-400
-4500,Other (Admin/Overheads),0,-37,-45,-53,-67,-79`;
-
-    const battleshipData = parseFinancialData(csvData);
-    if (battleshipData.length === 0) {
-      console.warn('No financial data available to display.');
-    }
+    let battleshipData = [];
+    let sliderMaxIndex = 0;
 
     const slider = document.getElementById('year-slider');
     const sliderStart = document.getElementById('slider-start');
     const sliderEnd = document.getElementById('slider-end');
     const yearLabel = document.getElementById('year-label');
+
+    slider.disabled = true;
+    slider.value = '0';
+    slider.setAttribute('aria-valuemin', '0');
+    slider.setAttribute('aria-valuemax', '0');
 
     const quadrants = {
       income: {
@@ -368,6 +391,17 @@
       },
     };
 
+    const showStatusMessage = (message) => {
+      Object.values(quadrants).forEach((quadrant) => {
+        quadrant.total.textContent = '$0';
+        quadrant.entries.innerHTML = '';
+        const placeholder = document.createElement('div');
+        placeholder.className = 'panel-placeholder';
+        placeholder.textContent = message;
+        quadrant.entries.appendChild(placeholder);
+      });
+    };
+
     const renderQuadrant = (key, data) => {
       const quadrant = quadrants[key];
       if (!quadrant) return;
@@ -378,7 +412,7 @@
       const activeNominals = data.nominals.filter((nominal) => nominal.value !== 0);
       if (activeNominals.length === 0) {
         const placeholder = document.createElement('div');
-        placeholder.className = 'flex items-center justify-center h-full text-slate-500 text-sm';
+        placeholder.className = 'panel-placeholder';
         placeholder.textContent = 'No Activity';
         quadrant.entries.appendChild(placeholder);
         return;
@@ -393,31 +427,111 @@
     const renderFrame = (index) => {
       const frame = battleshipData[index];
       if (!frame) return;
+      slider.value = String(index);
       yearLabel.textContent = frame.label;
       slider.setAttribute('aria-valuetext', frame.label);
+      slider.setAttribute('aria-valuenow', String(frame.year));
       renderQuadrant('income', frame.income);
       renderQuadrant('assets', frame.assets);
       renderQuadrant('liabilities', frame.liabilities);
       renderQuadrant('expenses', frame.expenses);
     };
 
-    slider.max = Math.max(0, battleshipData.length - 1);
-    slider.value = '0';
-
-    if (battleshipData.length > 0) {
-      sliderStart.textContent = battleshipData[0].year;
-      sliderEnd.textContent = battleshipData[battleshipData.length - 1].year;
-      renderFrame(0);
-    } else {
-      sliderStart.textContent = '';
-      sliderEnd.textContent = '';
-      yearLabel.textContent = 'No data available';
-    }
-
     slider.addEventListener('input', (event) => {
-      const newIndex = Number(event.target.value);
-      renderFrame(newIndex);
+      if (!battleshipData.length) return;
+      const sliderValue = Number(event.target.value);
+      if (!Number.isFinite(sliderValue)) return;
+      const constrainedValue = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
+      renderFrame(constrainedValue);
     });
+
+    const initialize = async () => {
+      startLoadingBar();
+      sliderMaxIndex = 0;
+      try {
+        const response = await fetch('projections.csv', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const csvText = await response.text();
+        battleshipData = parseFinancialData(csvText);
+
+        if (battleshipData.length === 0) {
+          console.warn('No financial data available to display.');
+          slider.disabled = true;
+          slider.value = '0';
+          sliderMaxIndex = 0;
+          slider.setAttribute('aria-valuemin', '0');
+          slider.setAttribute('aria-valuemax', '0');
+          slider.removeAttribute('aria-valuenow');
+          slider.removeAttribute('aria-valuetext');
+          sliderStart.textContent = '';
+          sliderEnd.textContent = '';
+          yearLabel.textContent = 'No data available';
+          showStatusMessage('No data available');
+          return;
+        }
+
+        slider.disabled = false;
+        slider.min = 0;
+        sliderMaxIndex = battleshipData.length - 1;
+        slider.max = sliderMaxIndex;
+        slider.step = 1;
+        slider.value = '0';
+        slider.setAttribute('aria-valuemin', String(battleshipData[0].year));
+        slider.setAttribute('aria-valuemax', String(battleshipData[sliderMaxIndex].year));
+        slider.setAttribute('aria-valuenow', String(battleshipData[0].year));
+        slider.setAttribute('aria-valuetext', battleshipData[0].label);
+        sliderEnd.textContent = battleshipData[0].year;
+        sliderStart.textContent = battleshipData[sliderMaxIndex].year;
+        renderFrame(0);
+      } catch (error) {
+        console.error('Error loading financial data:', error);
+        slider.disabled = true;
+        slider.value = '0';
+        sliderMaxIndex = 0;
+        slider.setAttribute('aria-valuemin', '0');
+        slider.setAttribute('aria-valuemax', '0');
+        slider.removeAttribute('aria-valuenow');
+        slider.removeAttribute('aria-valuetext');
+        sliderStart.textContent = '';
+        sliderEnd.textContent = '';
+        yearLabel.textContent = 'Unable to load data';
+        showStatusMessage('Unable to load data');
+      } finally {
+        finishLoadingBar();
+      }
+    };
+
+    const rowGroups = document.querySelectorAll('[data-row-group]');
+    rowGroups.forEach((group) => {
+      const toggle = group.querySelector('[data-row-toggle]');
+      if (!toggle) return;
+
+      toggle.addEventListener('click', () => {
+        const isExpanded = group.getAttribute('data-expanded') === 'true';
+        const nextState = !isExpanded;
+        group.setAttribute('data-expanded', String(nextState));
+        toggle.setAttribute('aria-expanded', String(nextState));
+        toggle.setAttribute('title', nextState ? 'Collapse row' : 'Expand row');
+        const label = toggle.querySelector('[data-toggle-label]');
+        if (label) {
+          label.textContent = nextState ? 'Collapse row' : 'Expand row';
+        }
+        if (nextState) {
+          group.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+        } else if (typeof toggle.focus === 'function') {
+          try {
+            toggle.focus({ preventScroll: true });
+          } catch (error) {
+            toggle.focus();
+          }
+        }
+      });
+    });
+
+    initialize();
   </script>
 </body>
 </html>

--- a/static/projections/projections.css
+++ b/static/projections/projections.css
@@ -99,10 +99,10 @@ body.page-body::selection {
 }
 
 .year-slider {
-  writing-mode: vertical-lr;
-  width: 0.5rem;
-  height: clamp(220px, 52vh, 360px);
-  flex: 1;
+  writing-mode: vertical-rl;
+  direction: rtl;
+  width: 19px;
+  min-height: 331px;
   margin-block: 0.75rem;
   appearance: none;
   background: transparent;

--- a/static/projections/projections.css
+++ b/static/projections/projections.css
@@ -1,0 +1,555 @@
+:root {
+  color-scheme: dark;
+  --page-bg: #0f172a;
+  --surface-bg: #1e293b;
+  --surface-border: rgba(148, 163, 184, 0.2);
+  --surface-shadow: rgba(15, 23, 42, 0.55);
+  --text-body: #cbd5f5;
+  --text-muted: #94a3b8;
+  --text-bright: #fbbf24;
+  --positive: #38bdf8;
+  --negative: #f87171;
+  --panel-income: linear-gradient(160deg, rgba(16, 185, 129, 0.55), rgba(15, 118, 110, 0.4));
+  --panel-assets: linear-gradient(160deg, rgba(59, 130, 246, 0.55), rgba(37, 99, 235, 0.4));
+  --panel-liabilities: linear-gradient(160deg, rgba(99, 102, 241, 0.55), rgba(79, 70, 229, 0.4));
+  --panel-expenses: linear-gradient(160deg, rgba(244, 63, 94, 0.55), rgba(225, 29, 72, 0.4));
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body.page-body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page-bg);
+  color: var(--text-body);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  padding: clamp(0.75rem, 1.5vw, 1.5rem);
+  display: flex;
+  justify-content: center;
+}
+
+body.page-body::selection {
+  background: rgba(251, 191, 36, 0.35);
+  color: #fff;
+}
+
+.loading-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: rgba(15, 23, 42, 0.5);
+  overflow: hidden;
+  z-index: 50;
+  display: none;
+  transition: opacity 0.3s ease;
+}
+
+.loading-bar[data-hidden="true"] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-bar__progress {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #fbbf24, #f59e0b);
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.45);
+  transition: width 0.2s ease-out;
+}
+
+.dashboard {
+  width: min(100%, 1120px);
+  background: var(--surface-bg);
+  border: 1px solid var(--surface-border);
+  border-radius: 18px;
+  box-shadow: 0 24px 40px var(--surface-shadow);
+  display: flex;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.slider-column {
+  width: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.slider-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+}
+
+.year-slider {
+  writing-mode: vertical-rl;
+  direction: rtl;
+  width: 100%;
+  height: clamp(220px, 52vh, 360px);
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.year-slider:focus {
+  outline: none;
+}
+
+.year-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #fbbf24;
+  border: 2px solid rgba(15, 23, 42, 0.85);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.year-slider::-webkit-slider-thumb:active {
+  transform: scale(1.05);
+}
+
+.year-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #fbbf24;
+  border: 2px solid rgba(15, 23, 42, 0.85);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.year-slider::-moz-range-thumb:active {
+  transform: scale(1.05);
+}
+
+.year-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+}
+
+.year-slider::-moz-range-track {
+  width: 100%;
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+}
+
+.content-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.year-header {
+  text-align: center;
+}
+
+.year-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 700;
+  color: var(--text-bright);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.row-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  padding: 1.1rem;
+  min-height: 240px;
+  display: flex;
+}
+
+.panel-overlay {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.07) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.07) 1px,
+      transparent 1px
+    );
+  background-size: 1rem 1rem;
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.panel[data-quadrant="income"] {
+  background: var(--panel-income);
+}
+
+.panel[data-quadrant="assets"] {
+  background: var(--panel-assets);
+}
+
+.panel[data-quadrant="liabilities"] {
+  background: var(--panel-liabilities);
+}
+
+.panel[data-quadrant="expenses"] {
+  background: var(--panel-expenses);
+}
+
+.panel-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #fff;
+}
+
+.panel-total {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+
+.panel-entries {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.panel-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.9rem;
+  min-height: 4rem;
+  padding: 0.5rem;
+}
+
+.row-toggle {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: var(--text-body);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  gap: 0.4rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.row-toggle:hover,
+.row-toggle:focus-visible {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.6);
+  color: #fff;
+  outline: none;
+}
+
+.row-toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+}
+
+.row-group[data-expanded="true"] .row-toggle-icon {
+  transform: rotate(180deg);
+}
+
+.row-group[data-expanded="false"] .panel-entries {
+  max-height: min(24rem, 60vh);
+  overflow-y: auto;
+}
+
+.row-group[data-expanded="true"] .panel-entries {
+  max-height: none;
+  overflow: visible;
+}
+
+.row-group[data-expanded="true"] .panel {
+  overflow: visible;
+}
+
+.entry-card {
+  position: relative;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  padding: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.entry-card:hover,
+.entry-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.35);
+}
+
+.entry-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -6px);
+  padding: 0.55rem 0.75rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: #fff;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  width: max-content;
+  max-width: 220px;
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+.entry-card:hover .entry-tooltip,
+.entry-card:focus-within .entry-tooltip {
+  opacity: 1;
+}
+
+.entry-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(15, 23, 42, 0.95) transparent transparent transparent;
+}
+
+.entry-tooltip-title {
+  margin: 0 0 0.25rem;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  padding-bottom: 0.25rem;
+}
+
+.entry-tooltip-value {
+  margin: 0;
+  font-weight: 600;
+}
+
+.entry-tooltip-value span {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.entry-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.entry-text {
+  flex: 1;
+}
+
+.entry-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.25rem;
+}
+
+.entry-title {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #fff;
+}
+
+.info-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  transition: color 0.2s ease;
+}
+
+.entry-card:hover .info-icon,
+.entry-card:focus-within .info-icon {
+  color: var(--text-bright);
+}
+
+.entry-value {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.entry-pin-wrapper {
+  margin-top: 0.5rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 10px;
+  padding: 0.4rem;
+}
+
+.pin-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  min-height: 0.75rem;
+}
+
+.pin-cell {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pin-dot {
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.pin-dot.positive {
+  background: #f8fafc;
+}
+
+.pin-dot.negative {
+  background: rgba(248, 113, 113, 0.85);
+}
+
+.pin-more {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  align-self: center;
+  margin-left: 0.25rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.45s ease-out both;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 960px) {
+  .dashboard {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .slider-column {
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+    height: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    min-height: 0;
+  }
+}
+
+@media (min-width: 721px) {
+  .panel-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/static/projections/projections.css
+++ b/static/projections/projections.css
@@ -81,7 +81,7 @@ body.page-body::selection {
 }
 
 .slider-column {
-  width: 72px;
+  width: 4rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -99,10 +99,11 @@ body.page-body::selection {
 }
 
 .year-slider {
-  writing-mode: vertical-rl;
-  direction: rtl;
-  width: 100%;
+  writing-mode: vertical-lr;
+  width: 0.5rem;
   height: clamp(220px, 52vh, 360px);
+  flex: 1;
+  margin-block: 0.75rem;
   appearance: none;
   background: transparent;
   cursor: pointer;

--- a/static/projections/projections.css
+++ b/static/projections/projections.css
@@ -35,6 +35,7 @@ body.page-body {
   padding: clamp(0.75rem, 1.5vw, 1.5rem);
   display: flex;
   justify-content: center;
+  align-items: stretch;
 }
 
 body.page-body::selection {
@@ -177,8 +178,7 @@ body.page-body::selection {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  flex: 1;
-  min-height: 0;
+  width: 100%;
 }
 
 .panel-grid {

--- a/static/projections/projections.csv
+++ b/static/projections/projections.csv
@@ -1,0 +1,21 @@
+Code, Description, 2024, 2025, 2026, 2027, 2028, 2029
+############# Lenders / Financing Summary #####################
+3200, Capital/Fund, 5300, 4000, 3000, 2000, 1000, 0
+3400, Interest Received, 54, 110, 220, 330, 440, 550
+3600, Loan Repayments Received, 0, 300, 0, 0, 0, 5000
+############# Assets #########################################
+0000, Cash & Bank Balance, 400, 700, 1000, 1400, 1600, 1200
+1200, Vehicles (Gross), 260, 1055, 1850, 1850, 1850, 1850
+1201, Property (Land & Building), 0, 0, 0, 3000, 3000, 3000
+1300, Accounts Receivable, 100, 400, 700, 1000, 1200, 1400
+1400, Other Assets, 506, -240, -735, -3445, -2805, -7465
+2600, Equity (Retained Earnings), 60, 250, 550, 900, 1200, 1400
+############# Liabilities ####################################
+2000, Bonds Payable (Drawn), -1000, -2000, -3000, -4000, -5000, 0
+2200, Startup Loan Payable, -300, 0, 0, 0, 0, 0
+2300, Accumulated Depreciation, -26, -130, -300, -600, -900, -1200
+2400, Taxes Payable, 0, -20, -40, -70, -100, -130
+2500, Other Payables, 0, -15, -25, -35, -45, -55
+############# Expenses #######################################
+4000, Driver & Supplier Costs, -80, -450, -750, -950, -1050, -1150
+4500, Admin & Overheads, -50, -70, -90, -110, -130, -150


### PR DESCRIPTION
## Summary
- replace the projections dashboard's Tailwind CDN usage with a dedicated stylesheet so it can run cleanly on static hosting
- update the year slider logic to initialise at the 2024 position and guard against undefined sliderMaxIndex errors while rendering
- keep the expandable projection groups scrollable and style the dynamic entries, tooltips, and loading bar with the new CSS classes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904ba89f2548332bac28c95e8ddf6f6