### PR TITLE
Default projections slider to 2024 and scale pins for high values

### DIFF
--- a/static/projections/index.html
+++ b/static/projections/index.html
@@ -4,81 +4,20 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Financial Model</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    html {
-      scroll-behavior: smooth;
-    }
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(10px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    .animate-fade-in {
-      animation: fadeIn 0.5s ease-out forwards;
-    }
-    #loading-bar-container {
-      transition: opacity 0.3s ease;
-    }
-    #loading-bar-container[data-hidden="true"] {
-      opacity: 0;
-      pointer-events: none;
-    }
-    #loading-bar {
-      width: 0%;
-    }
-
-    #year-slider {
-      writing-mode: vertical-rl;
-      direction: rtl;
-    }
-
-    [data-row-group] {
-      transition: flex 0.35s ease, max-height 0.35s ease;
-    }
-
-    [data-row-group][data-expanded="true"] {
-      flex: 0 0 auto;
-    }
-
-    [data-row-group] section {
-      transition: max-height 0.35s ease;
-    }
-
-    [data-row-group][data-expanded="false"] [data-entries] {
-      overflow-y: auto;
-      max-height: min(24rem, 60vh);
-    }
-
-    [data-row-group][data-expanded="true"] [data-entries] {
-      overflow-y: visible;
-      max-height: none;
-    }
-
-    [data-row-group][data-expanded="true"] section {
-      overflow: visible;
-    }
-
-    [data-row-toggle] svg {
-      transition: transform 0.3s ease;
-    }
-
-    [data-row-group][data-expanded="true"] [data-row-toggle] svg {
-      transform: rotate(180deg);
-    }
-  </style>
+  <link rel="stylesheet" href="projections.css" />
 </head>
-<body class="bg-slate-900 text-slate-300 font-sans antialiased min-h-screen p-2 sm:p-4">
+<body class="page-body">
   <div
     id="loading-bar-container"
-    class="fixed top-0 left-0 w-full h-1 bg-slate-700/60 overflow-hidden z-50"
+    class="loading-bar"
     role="status"
     aria-live="polite"
   >
-    <div id="loading-bar" class="h-full bg-amber-400 shadow-lg shadow-amber-500/40 transition-all duration-200 ease-out"></div>
+    <div id="loading-bar" class="loading-bar__progress"></div>
   </div>
-  <main class="bg-slate-800 p-2 sm:p-4 rounded-lg shadow-lg ring-1 ring-white/10 flex gap-4 w-full max-w-7xl mx-auto">
-    <div class="flex flex-col items-center justify-center w-16 py-4">
-      <span id="slider-end" class="text-xs text-slate-400 font-semibold transform -rotate-90 origin-center whitespace-nowrap"></span>
+  <main class="dashboard">
+    <div class="slider-column">
+      <span id="slider-end" class="slider-label"></span>
       <input
         id="year-slider"
         class="year-slider"
@@ -86,113 +25,97 @@
         min="0"
         step="1"
         value="0"
-        class="flex-grow w-2 h-full bg-slate-700 rounded-lg appearance-none cursor-pointer my-4"
         aria-orientation="vertical"
         aria-label="Financial Year Slider"
       />
-      <span id="slider-start" class="text-xs text-slate-400 font-semibold transform -rotate-90 origin-center whitespace-nowrap"></span>
+      <span id="slider-start" class="slider-label"></span>
     </div>
 
-    <div class="flex-grow min-w-0 flex flex-col">
-      <div class="text-center mb-2">
-        <h3 id="year-label" class="text-lg font-bold text-amber-400"></h3>
+    <div class="content-column">
+      <div class="year-header">
+        <h3 id="year-label" class="year-title"></h3>
       </div>
-      <div class="flex flex-col gap-3 flex-grow">
-        <div class="flex flex-col flex-1 min-h-0" data-row-group="top" data-expanded="false">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-4 flex-1 min-h-0">
-            <section class="relative p-3 rounded-lg flex flex-col bg-emerald-900/70 overflow-hidden" data-quadrant="income">
-              <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-              <div class="relative z-10 flex-grow flex flex-col min-h-0">
-                <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-                  <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Lenders / Financing Summary</h4>
-                  <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-                </div>
-                <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-              </div>
-            </section>
 
-            <section class="relative p-3 rounded-lg flex flex-col bg-sky-900/70 overflow-hidden" data-quadrant="assets">
-              <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-              <div class="relative z-10 flex-grow flex flex-col min-h-0">
-                <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-                  <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Assets (Owned Value)</h4>
-                  <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-                </div>
-                <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-              </div>
-            </section>
-          </div>
-          <button
-            type="button"
-            class="mt-1 mx-auto inline-flex items-center justify-center rounded-full bg-slate-700/70 px-3 py-2 text-sm font-semibold text-slate-200 shadow ring-1 ring-white/10 transition hover:bg-slate-600/70"
-            data-row-toggle
-            aria-expanded="false"
-            title="Expand row"
-          >
-            <span aria-hidden="true" class="flex items-center justify-center">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                class="w-5 h-5"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
-              </svg>
-            </span>
-            <span class="sr-only" data-toggle-label>Expand row</span>
-          </button>
+      <div class="row-group" data-row-group="top" data-expanded="false">
+        <div class="panel-grid">
+          <section class="panel" data-quadrant="income">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <header class="panel-header">
+                <h4 class="panel-title">Lenders / Financing Summary</h4>
+                <p class="panel-total" data-total></p>
+              </header>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
+
+          <section class="panel" data-quadrant="assets">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <header class="panel-header">
+                <h4 class="panel-title">Assets (Owned Value)</h4>
+                <p class="panel-total" data-total></p>
+              </header>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
         </div>
-
-        <div class="flex flex-col flex-1 min-h-0" data-row-group="bottom" data-expanded="false">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-4 flex-1 min-h-0">
-            <section class="relative p-3 rounded-lg flex flex-col bg-indigo-900/70 overflow-hidden" data-quadrant="liabilities">
-              <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-              <div class="relative z-10 flex-grow flex flex-col min-h-0">
-                <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-                  <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Liabilities (Owed Value)</h4>
-                  <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-                </div>
-                <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-              </div>
-            </section>
-
-            <section class="relative p-3 rounded-lg flex flex-col bg-rose-900/70 overflow-hidden" data-quadrant="expenses">
-              <div aria-hidden="true" class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1rem_1rem] opacity-50"></div>
-              <div class="relative z-10 flex-grow flex flex-col min-h-0">
-                <div class="flex justify-between items-baseline border-b border-white/10 pb-1 mb-2 flex-shrink-0">
-                  <h4 class="text-sm sm:text-base font-bold text-white uppercase tracking-wider">Expenses (Operational &amp; Financing)</h4>
-                  <p class="text-lg sm:text-xl font-extrabold text-white" data-total></p>
-                </div>
-                <div class="flex-grow overflow-y-auto pr-1" data-entries aria-live="polite"></div>
-              </div>
-            </section>
-          </div>
-          <button
-            type="button"
-            class="mt-1 mx-auto inline-flex items-center justify-center rounded-full bg-slate-700/70 px-3 py-2 text-sm font-semibold text-slate-200 shadow ring-1 ring-white/10 transition hover:bg-slate-600/70"
-            data-row-toggle
-            aria-expanded="false"
-            title="Expand row"
-          >
-            <span aria-hidden="true" class="flex items-center justify-center">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                class="w-5 h-5"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
-              </svg>
-            </span>
-            <span class="sr-only" data-toggle-label>Expand row</span>
-          </button>
-        </div>
+        <button
+          type="button"
+          class="row-toggle"
+          data-row-toggle
+          aria-expanded="false"
+          title="Expand row"
+        >
+          <span aria-hidden="true" class="row-toggle-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="20" height="20">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
+            </svg>
+          </span>
+          <span class="sr-only" data-toggle-label>Expand row</span>
+        </button>
       </div>
-    </section>
+
+      <div class="row-group" data-row-group="bottom" data-expanded="false">
+        <div class="panel-grid">
+          <section class="panel" data-quadrant="liabilities">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <header class="panel-header">
+                <h4 class="panel-title">Liabilities (Owed Value)</h4>
+                <p class="panel-total" data-total></p>
+              </header>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
+
+          <section class="panel" data-quadrant="expenses">
+            <div aria-hidden="true" class="panel-overlay"></div>
+            <div class="panel-inner">
+              <header class="panel-header">
+                <h4 class="panel-title">Expenses (Operational &amp; Financing)</h4>
+                <p class="panel-total" data-total></p>
+              </header>
+              <div class="panel-entries" data-entries aria-live="polite"></div>
+            </div>
+          </section>
+        </div>
+        <button
+          type="button"
+          class="row-toggle"
+          data-row-toggle
+          aria-expanded="false"
+          title="Expand row"
+        >
+          <span aria-hidden="true" class="row-toggle-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="20" height="20">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25M19.5 12.75 12 20.25 4.5 12.75" />
+            </svg>
+          </span>
+          <span class="sr-only" data-toggle-label>Expand row</span>
+        </button>
+      </div>
+    </div>
   </main>
 
   <script>
@@ -264,36 +187,63 @@
       const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
       path.setAttribute('stroke-linecap', 'round');
       path.setAttribute('stroke-linejoin', 'round');
-      path.setAttribute('d', 'm11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z');
+      path.setAttribute(
+        'd',
+        'm11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z'
+      );
 
       svg.appendChild(path);
       return svg;
     };
 
     const createPinGrid = (value) => {
-      const PIN_VALUE = 10000;
-      const pinCount = Math.floor(Math.abs(value) / PIN_VALUE);
-      if (pinCount === 0) return null;
+      const TEN_K_PIN_VALUE = 10_000;
+      const HUNDRED_K_PIN_VALUE = 100_000;
+      const absValue = Math.abs(value);
+
+      const hundredPinCount = Math.floor(absValue / HUNDRED_K_PIN_VALUE);
+      const remainingAfterHundreds = absValue - hundredPinCount * HUNDRED_K_PIN_VALUE;
+      const tenPinCount = Math.floor(remainingAfterHundreds / TEN_K_PIN_VALUE);
+      const totalPinCount = hundredPinCount + tenPinCount;
+
+      if (totalPinCount === 0) return null;
 
       const pinGrid = document.createElement('div');
       pinGrid.className = 'pin-grid';
-      const displayCount = Math.min(pinCount, 200);
 
-      for (let i = 0; i < displayCount; i += 1) {
+      const maxVisiblePins = 200;
+      let renderedPins = 0;
+
+      const makePin = (title, classes) => {
         const wrapper = document.createElement('div');
         wrapper.className = 'pin-cell';
-        wrapper.title = '$10,000';
+        wrapper.title = title;
 
         const dot = document.createElement('div');
-        dot.className = `pin-dot ${value >= 0 ? 'positive' : 'negative'}`;
+        dot.className = ['pin-dot', ...classes].join(' ');
         wrapper.appendChild(dot);
-        pinGrid.appendChild(wrapper);
-      }
 
-      if (pinCount > displayCount) {
+        return wrapper;
+      };
+
+      const isPositive = value >= 0;
+      const tenPinClasses = ['pin-ten', isPositive ? 'positive' : 'negative'];
+      const hundredPinClasses = ['pin-hundred', isPositive ? 'positive' : 'negative'];
+
+      const appendPins = (count, title, classes) => {
+        for (let i = 0; i < count && renderedPins < maxVisiblePins; i += 1) {
+          pinGrid.appendChild(makePin(title, classes));
+          renderedPins += 1;
+        }
+      };
+
+      appendPins(hundredPinCount, '$100,000', hundredPinClasses);
+      appendPins(tenPinCount, '$10,000', tenPinClasses);
+
+      if (renderedPins < totalPinCount) {
         const more = document.createElement('div');
         more.className = 'pin-more';
-        more.textContent = `+${pinCount - displayCount} more`;
+        more.textContent = `+${totalPinCount - renderedPins} more`;
         pinGrid.appendChild(more);
       }
 
@@ -442,7 +392,13 @@
     const sliderEnd = document.getElementById('slider-end');
     const yearLabel = document.getElementById('year-label');
 
+    let sliderMaxIndex = 0;
+
     slider.disabled = true;
+    slider.setAttribute('aria-valuemin', '0');
+    slider.setAttribute('aria-valuemax', '0');
+    slider.setAttribute('aria-valuenow', '0');
+    slider.setAttribute('aria-valuetext', '');
     yearLabel.textContent = 'Loading projections…';
 
     const quadrants = {
@@ -464,12 +420,38 @@
       },
     };
 
+    const toggleGroups = () => {
+      const rowGroups = document.querySelectorAll('[data-row-group]');
+      rowGroups.forEach((group) => {
+        const toggleButton = group.querySelector('[data-row-toggle]');
+        if (!toggleButton) return;
+        const toggleLabel = toggleButton.querySelector('[data-toggle-label]');
+
+        const updateToggleState = () => {
+          const expanded = group.getAttribute('data-expanded') === 'true';
+          toggleButton.setAttribute('aria-expanded', String(expanded));
+          if (toggleLabel) {
+            toggleLabel.textContent = expanded ? 'Collapse row' : 'Expand row';
+          }
+          toggleButton.title = expanded ? 'Collapse row' : 'Expand row';
+        };
+
+        toggleButton.addEventListener('click', () => {
+          const expanded = group.getAttribute('data-expanded') === 'true';
+          group.setAttribute('data-expanded', expanded ? 'false' : 'true');
+          updateToggleState();
+        });
+
+        updateToggleState();
+      });
+    };
+
     const showStatusMessage = (message) => {
       Object.values(quadrants).forEach((quadrant) => {
         quadrant.total.textContent = formatCurrency(0);
         quadrant.entries.innerHTML = '';
         const placeholder = document.createElement('div');
-        placeholder.className = 'flex items-center justify-center h-full text-slate-500 text-sm text-center px-2';
+        placeholder.className = 'panel-placeholder';
         placeholder.textContent = message;
         quadrant.entries.appendChild(placeholder);
       });
@@ -500,8 +482,7 @@
     const updateSliderForIndex = (index) => {
       const frame = battleshipData[index];
       if (!frame) return;
-      const sliderPosition = sliderMaxIndex - index;
-      slider.value = String(sliderPosition);
+      slider.value = String(index);
       slider.setAttribute('aria-valuenow', String(frame.year));
       slider.setAttribute('aria-valuetext', frame.label);
     };
@@ -511,10 +492,6 @@
       if (!frame) return;
       updateSliderForIndex(index);
       yearLabel.textContent = frame.label;
-      const sliderPosition = sliderMaxIndex - index;
-      slider.value = String(sliderPosition);
-      slider.setAttribute('aria-valuetext', frame.label);
-      slider.setAttribute('aria-valuenow', frame.year);
       renderQuadrant('income', frame.income);
       renderQuadrant('assets', frame.assets);
       renderQuadrant('liabilities', frame.liabilities);
@@ -524,12 +501,12 @@
     slider.addEventListener('input', (event) => {
       if (!battleshipData.length) return;
       const sliderValue = Number(event.target.value);
-      const constrainedValue = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
-      const newIndex = sliderMaxIndex - constrainedValue;
+      const newIndex = Math.max(0, Math.min(sliderMaxIndex, sliderValue));
       renderFrame(newIndex);
     });
 
     const initialize = async () => {
+      startLoadingBar();
       try {
         const response = await fetch('projections.csv');
         if (!response.ok) {
@@ -542,7 +519,11 @@
         if (battleshipData.length === 0) {
           console.warn('No financial data available to display.');
           slider.disabled = true;
+          sliderMaxIndex = 0;
           slider.value = '0';
+          slider.setAttribute('aria-valuemax', '0');
+          slider.setAttribute('aria-valuenow', '0');
+          slider.setAttribute('aria-valuetext', '');
           sliderStart.textContent = '';
           sliderEnd.textContent = '';
           yearLabel.textContent = 'No data available';
@@ -551,22 +532,34 @@
         }
 
         slider.disabled = false;
-        slider.max = Math.max(0, battleshipData.length - 1);
+        sliderMaxIndex = Math.max(0, battleshipData.length - 1);
+        slider.max = String(sliderMaxIndex);
         slider.value = '0';
-        sliderStart.textContent = battleshipData[0].year;
-        sliderEnd.textContent = battleshipData[battleshipData.length - 1].year;
+        slider.setAttribute('aria-valuemin', '0');
+        slider.setAttribute('aria-valuemax', String(sliderMaxIndex));
+        sliderStart.textContent = battleshipData[battleshipData.length - 1].year;
+        sliderEnd.textContent = battleshipData[0].year;
         renderFrame(0);
       } catch (error) {
         console.error('Error loading financial data:', error);
         slider.disabled = true;
+        sliderMaxIndex = 0;
+        slider.max = '0';
         slider.value = '0';
+        slider.setAttribute('aria-valuemin', '0');
+        slider.setAttribute('aria-valuemax', '0');
+        slider.setAttribute('aria-valuenow', '0');
+        slider.setAttribute('aria-valuetext', '');
         sliderStart.textContent = '';
         sliderEnd.textContent = '';
         yearLabel.textContent = 'Unable to load data';
         showStatusMessage('Unable to load data');
+      } finally {
+        finishLoadingBar();
       }
     };
 
+    toggleGroups();
     initialize();
   </script>
 </body>

--- a/static/projections/projections.css
+++ b/static/projections/projections.css
@@ -100,7 +100,7 @@ body.page-body::selection {
 
 .year-slider {
   writing-mode: vertical-rl;
-  direction: rtl;
+  direction: ltr;
   width: 19px;
   min-height: 331px;
   margin-block: 0.75rem;
@@ -180,6 +180,17 @@ body.page-body::selection {
   flex-direction: column;
   gap: 0.75rem;
   width: 100%;
+  flex: 1 1 0%;
+  min-height: 0;
+  transition: flex 0.35s ease, max-height 0.35s ease;
+}
+
+.row-group section {
+  transition: max-height 0.35s ease;
+}
+
+.row-group[data-expanded="true"] {
+  flex: 0 0 auto;
 }
 
 .panel-grid {
@@ -483,12 +494,25 @@ body.page-body::selection {
   border-radius: 999px;
 }
 
-.pin-dot.positive {
+.pin-dot.pin-ten.positive {
   background: #f8fafc;
 }
 
-.pin-dot.negative {
+.pin-dot.pin-ten.negative {
   background: rgba(248, 113, 113, 0.85);
+}
+
+.pin-dot.pin-hundred {
+  background: #facc15;
+}
+
+.pin-dot.pin-hundred.positive {
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.6);
+}
+
+.pin-dot.pin-hundred.negative {
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.65);
+  opacity: 0.85;
 }
 
 .pin-more {


### PR DESCRIPTION
## Summary
- default the projections year slider to the top 2024 position and adjust the labels so 2024 appears at the top of the control
- simplify the data viz by rendering new yellow pins for each $100K increment while keeping the existing $10K pins for finer detail

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_6905774486088332886aa078f771cd3c