### PR TITLE
Make app store cards square across app store pages

### DIFF
--- a/static/gui/app-store/002b.html
+++ b/static/gui/app-store/002b.html
@@ -14,7 +14,7 @@
         <link href="apps/999-999/style.css" rel="stylesheet">
         <link href="css/appstore-common.css" rel="stylesheet">
 </head>
-<body style="overflow: inherit !important; height: inherit !important; display: visible;" onload="document.body.classList.add('loaded');">
+<body class="app-store-page" style="overflow: inherit !important; height: inherit !important; display: visible;" onload="document.body.classList.add('loaded');">
         <div class="container">
                 <div class="box">
                         <div class="box-row">
@@ -38,7 +38,7 @@
                 </div>
         </div>
 
-        <div id="apps-container" class="apps-container"></div>
+        <div id="apps-container" class="apps-container app-store-grid"></div>
 
         <script>
 function toggleAppInstallation(appId) {
@@ -62,7 +62,11 @@ function getAppLink(appId) {
 }
 
 function handleDragStart(event) {
-    event.dataTransfer.setData('text/plain', event.target.id);
+    const source = event.currentTarget;
+    const appId = source.dataset.appId || source.id || '';
+    if (appId) {
+        event.dataTransfer.setData('text/plain', appId);
+    }
 }
 
 function updateHomeScreen() {
@@ -73,22 +77,36 @@ function updateHomeScreen() {
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
         const appElement = document.createElement('a');
+        const isPlaceholder = appId === '999-999';
         appElement.href = getAppLink(appId); // Set the hyperlink
-        appElement.style.cursor = 'pointer';
+        appElement.className = `app-card-link${isPlaceholder ? ' app-card-link--inactive' : ''}`;
+        appElement.dataset.appId = appId;
+        appElement.draggable = true;
+        appElement.style.cursor = isPlaceholder ? 'default' : 'pointer';
+        if (isPlaceholder) {
+            appElement.setAttribute('aria-disabled', 'true');
+        }
+
+        const toggleAttributes = [];
+        if (appInstalled || isPlaceholder) {
+            toggleAttributes.push('checked');
+        }
+        if (isPlaceholder) {
+            toggleAttributes.push('disabled');
+        }
+        const cardClasses = `app-card${isPlaceholder ? ' app-card--disabled' : ''}`;
+        const altText = isPlaceholder ? 'Add new app' : `Hβnβ entertainment app icon ${appId}`;
+
         appElement.innerHTML = `
-            <div class="square-${appId}">
-                <div class="content-${appId}">
-                    <div class="table-${appId}">
-                        <div class="table-cell-${appId}">
-                            <img class="app-icon-image" src="apps/${appId}/logo.png">
-                            <div class="toggle">
-                                <input class="app-checkbox" id="${appId}" type="checkbox" ${appInstalled ? 'checked' : ''}>
-                                <label class="app-label install" for="${appId}"><span class="thumb"></span></label>
-                            </div>
-                        </div>
-                    </div>
+            <article class="${cardClasses}" data-app-id="${appId}">
+                <div class="app-card__icon-wrapper">
+                    <img class="app-card__icon" src="apps/${appId}/logo.png" alt="${altText}">
                 </div>
-            </div>
+                <div class="app-card__toggle">
+                    <input class="app-checkbox" id="${appId}" type="checkbox" ${toggleAttributes.join(' ')}>
+                    <label class="app-label install" for="${appId}"><span class="thumb"></span></label>
+                </div>
+            </article>
         `;
         appElement.addEventListener('dragstart', handleDragStart);
         appsContainer.appendChild(appElement);

--- a/static/gui/app-store/css/appstore.css
+++ b/static/gui/app-store/css/appstore.css
@@ -20,8 +20,6 @@ body.app-store-page {
     color: rgba(255,255,255,0.85);
     padding-top: clamp(90px, 5vw + 60px, 140px);
     overflow: hidden;
-    --app-card-size: 16%;
-    --app-card-gap: 1.66%;
 }
 
 .breadcrumb {
@@ -193,9 +191,14 @@ background-color: rgba(255,255,255,0.3)!important;
 
 
 .app-store-grid {
+    --app-card-columns: 5;
+    --app-card-gap: 1.99%;
+    --app-card-ratio: 1;
+    --app-card-size: calc((100% / var(--app-card-columns)) - (var(--app-card-gap) * 2));
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
+    align-content: flex-start;
     width: 100%;
     clear: both;
     position: fixed;
@@ -204,7 +207,7 @@ background-color: rgba(255,255,255,0.3)!important;
     right: 0;
     bottom: 6vh;
     margin: 0;
-    padding: 0 calc(var(--app-card-gap) * 2) 4vh;
+    padding: 0 0 4vh;
     overflow-y: auto;
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
@@ -216,9 +219,21 @@ background-color: rgba(255,255,255,0.3)!important;
     flex: 0 0 var(--app-card-size);
     max-width: var(--app-card-size);
     margin: var(--app-card-gap);
-    padding-bottom: var(--app-card-size);
     text-decoration: none;
     color: inherit;
+    aspect-ratio: var(--app-card-ratio);
+}
+
+.app-card-link::before {
+    content: "";
+    display: block;
+    padding-bottom: calc(100% / var(--app-card-ratio));
+}
+
+@supports (aspect-ratio: 1) {
+    .app-card-link::before {
+        display: none;
+    }
 }
 
 .app-card-link:hover,
@@ -234,17 +249,20 @@ background-color: rgba(255,255,255,0.3)!important;
 .app-card {
     position: absolute;
     inset: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    display: grid;
+    grid-template-rows: 1fr auto;
+    justify-items: center;
     align-items: center;
-    padding: 12% 10% 18%;
+    padding: clamp(12px, 7%, 20px);
     box-sizing: border-box;
     background: rgb(44,12,33);
-    border: 1.5px solid rgba(255,255,255,0.3);
+    border: 2px solid rgba(255,255,255,0.1);
     border-radius: 0.5em;
     transition: border-color 0.2s ease, background-color 0.2s ease;
-    gap: 6%;
+    row-gap: clamp(8px, 4%, 16px);
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 .app-card--disabled .app-card__toggle {
@@ -253,19 +271,20 @@ background-color: rgba(255,255,255,0.3)!important;
 }
 
 .app-card__icon-wrapper {
-    flex: 1 1 auto;
     width: 100%;
+    height: 100%;
+    min-height: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 2% 0;
+    padding: clamp(6px, 4%, 12px) 0;
 }
 
 .app-card__icon {
     display: block;
     width: 100%;
-    max-width: 60%;
-    max-height: 60%;
+    max-width: 70%;
+    max-height: 100%;
     object-fit: contain;
     object-position: center;
 }
@@ -278,9 +297,10 @@ background-color: rgba(255,255,255,0.3)!important;
 .app-card__toggle {
     width: 100%;
     display: flex;
+    align-items: center;
     justify-content: center;
-    margin-top: auto;
-    padding-top: 6%;
+    justify-self: stretch;
+    padding-top: clamp(8px, 4%, 16px);
 }
 
 .app-checkbox {
@@ -323,30 +343,26 @@ background-color: rgba(255,255,255,0.3)!important;
 }
 
 @media (max-width: 1400px) {
-    body.app-store-page {
-        --app-card-size: calc(25% - (var(--app-card-gap) * 2));
+    .app-store-grid {
+        --app-card-columns: 4;
     }
 }
 
 @media (max-width: 820px) {
-    body.app-store-page {
-        --app-card-size: calc(33.33% - (var(--app-card-gap) * 2));
+    .app-store-grid {
+        --app-card-columns: 3;
     }
 }
 
 @media (max-width: 640px) {
-    body.app-store-page {
-        --app-card-size: calc(50% - (var(--app-card-gap) * 2));
-    }
-
-    .app-card__toggle {
-        padding-top: 8%;
+    .app-store-grid {
+        --app-card-columns: 2;
     }
 }
 
 @media (max-width: 420px) {
-    body.app-store-page {
-        --app-card-size: calc(100% - (var(--app-card-gap) * 2));
+    .app-store-grid {
+        --app-card-columns: 1;
     }
 }
 


### PR DESCRIPTION
## Summary
- update the shared app store grid variables to enforce a 1:1 aspect ratio for every card
- refactor the card layout to a grid so icons and toggles stay contained while filling the tile
- expose the responsive column custom properties on `.app-store-grid` so other pages can reuse the same stylesheet

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910266d705c8332b181a979a96c96cf)