### PR TITLE
Ensure app store page background fills viewport

### DIFF
--- a/static/gui/app-store/000.html
+++ b/static/gui/app-store/000.html
@@ -19,7 +19,8 @@
         html {
            overflow-x: hidden!important;
            height: -webkit-fill-available;
-           background-color: rgb(44,12,33);
+           background: rgb(44,12,33)!important;
+           background-color: rgb(44,12,33)!important;
            width: 100%;
            min-width: 100vw;
         }
@@ -29,7 +30,8 @@
            min-height: 100vh;
            width: 100%;
            min-width: 100vw;
-           background-color: rgb(44,12,33);
+           background: rgb(44,12,33)!important;
+           background-color: rgb(44,12,33)!important;
            overflow-x: hidden;
         }
 


### PR DESCRIPTION
## Summary
- force the html and body backgrounds on the app store landing page to use the brand colour so any viewport gaps are filled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691032c81f6c833285310643913b7100)