### PR TITLE
Enable configurable Add+ app icon visibility

### DIFF
--- a/static/gui/app-store/002b.html
+++ b/static/gui/app-store/002b.html
@@ -41,10 +41,34 @@
         <div id="apps-container" class="apps-container app-store-grid"></div>
 
         <script>
-function toggleAppInstallation(appId) {
-    if (appId === '999-999') return;
-    const appInstalled = localStorage.getItem(appId) === 'added';
-    localStorage.setItem(appId, appInstalled ? '' : 'added' );
+const ADD_ICON_ID = '999-999';
+const SHOULD_LOCK_ADD_ICON = window.location.pathname.includes('/app-store/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return SHOULD_LOCK_ADD_ICON || storedValue !== 'removed';
+}
+
+function toggleAppInstallation(appId, checkbox) {
+    if (appId === ADD_ICON_ID) {
+        if (SHOULD_LOCK_ADD_ICON) {
+            checkbox.checked = true;
+            return;
+        }
+
+        if (checkbox.checked) {
+            localStorage.setItem(appId, 'added');
+        } else {
+            localStorage.setItem(appId, 'removed');
+        }
+        return;
+    }
+
+    if (checkbox.checked) {
+        localStorage.setItem(appId, 'added');
+    } else {
+        localStorage.removeItem(appId);
+    }
     // Removed updateHomeScreen() call here, as window.addEventListener('storage') will handle it
 }
 
@@ -75,26 +99,31 @@ function updateHomeScreen() {
 
     const appIds = ['002-001', '002-002', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
-        const appInstalled = localStorage.getItem(appId) === 'added';
         const appElement = document.createElement('a');
-        const isPlaceholder = appId === '999-999';
+        const isPlaceholder = appId === ADD_ICON_ID;
+        const storedValue = localStorage.getItem(appId);
+        const isInstalled = storedValue === 'added';
+        const placeholderEnabled = isPlaceholder ? isAddIconEnabled() : false;
         appElement.href = getAppLink(appId); // Set the hyperlink
-        appElement.className = `app-card-link${isPlaceholder ? ' app-card-link--inactive' : ''}`;
-        appElement.dataset.appId = appId;
-        appElement.draggable = true;
-        appElement.style.cursor = isPlaceholder ? 'default' : 'pointer';
-        if (isPlaceholder) {
+        const linkClasses = ['app-card-link'];
+        if (isPlaceholder && SHOULD_LOCK_ADD_ICON) {
+            linkClasses.push('app-card-link--inactive');
             appElement.setAttribute('aria-disabled', 'true');
         }
+        appElement.className = linkClasses.join(' ');
+        appElement.dataset.appId = appId;
+        appElement.draggable = true;
+        appElement.style.cursor = isPlaceholder && SHOULD_LOCK_ADD_ICON ? 'default' : 'pointer';
 
         const toggleAttributes = [];
-        if (appInstalled || isPlaceholder) {
+        const isChecked = isPlaceholder ? placeholderEnabled : isInstalled;
+        if (isChecked) {
             toggleAttributes.push('checked');
         }
-        if (isPlaceholder) {
+        if (isPlaceholder && SHOULD_LOCK_ADD_ICON) {
             toggleAttributes.push('disabled');
         }
-        const cardClasses = `app-card${isPlaceholder ? ' app-card--disabled' : ''}`;
+        const cardClasses = `app-card${isPlaceholder && SHOULD_LOCK_ADD_ICON ? ' app-card--disabled' : ''}`;
         const altText = isPlaceholder ? 'Add new app' : `Hβnβ entertainment app icon ${appId}`;
 
         appElement.innerHTML = `
@@ -116,7 +145,7 @@ function updateHomeScreen() {
     const checkboxes = document.querySelectorAll('.app-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('click', function() {
-            toggleAppInstallation(this.id);
+            toggleAppInstallation(this.id, this);
         });
     });
 }

--- a/static/gui/app-store/js/app-toggle.js
+++ b/static/gui/app-store/js/app-toggle.js
@@ -1,4 +1,31 @@
 (function () {
+  function shouldLockAddAppIcon() {
+    const path = window.location.pathname || '';
+    return path.includes('/app-store/006');
+  }
+
+  function setAddIconCardState(card, checkbox, isLocked) {
+    const cardLink = card.closest('.app-card-link');
+
+    if (isLocked) {
+      checkbox.checked = true;
+      checkbox.setAttribute('disabled', 'disabled');
+      card.classList.add('app-card--disabled');
+      if (cardLink) {
+        cardLink.classList.add('app-card-link--inactive');
+        cardLink.setAttribute('aria-disabled', 'true');
+      }
+      return;
+    }
+
+    checkbox.removeAttribute('disabled');
+    card.classList.remove('app-card--disabled');
+    if (cardLink) {
+      cardLink.classList.remove('app-card-link--inactive');
+      cardLink.removeAttribute('aria-disabled');
+    }
+  }
+
   function syncCheckboxState(card) {
     const appId = card.dataset.appId;
     const checkbox = card.querySelector('.app-checkbox');
@@ -7,19 +34,35 @@
     }
 
     const storedValue = localStorage.getItem(appId);
-    const isInstalled = storedValue === 'added' || (appId === '999-999' && storedValue !== 'removed');
-
-    checkbox.checked = appId === '999-999' ? true : isInstalled;
 
     if (appId === '999-999') {
-      checkbox.setAttribute('disabled', 'disabled');
-      card.classList.add('app-card--disabled');
+      const isLocked = shouldLockAddAppIcon();
+      setAddIconCardState(card, checkbox, isLocked);
+      if (!isLocked) {
+        const isEnabled = storedValue !== 'removed';
+        checkbox.checked = isEnabled;
+      }
+      return;
     }
+
+    const isInstalled = storedValue === 'added';
+    checkbox.checked = isInstalled;
   }
 
-  function toggleAppInstallation(appId, checkbox) {
+  function toggleAppInstallation(appId, checkbox, card) {
     if (appId === '999-999') {
-      checkbox.checked = true;
+      const isLocked = shouldLockAddAppIcon();
+      if (isLocked) {
+        checkbox.checked = true;
+        setAddIconCardState(card, checkbox, true);
+        return;
+      }
+
+      if (checkbox.checked) {
+        localStorage.setItem(appId, 'added');
+      } else {
+        localStorage.setItem(appId, 'removed');
+      }
       return;
     }
 
@@ -43,7 +86,7 @@
       syncCheckboxState(card);
 
       checkbox.addEventListener('change', function () {
-        toggleAppInstallation(appId, checkbox);
+        toggleAppInstallation(appId, checkbox, card);
       });
     });
   });

--- a/static/gui/dashboard/002-demo.html
+++ b/static/gui/dashboard/002-demo.html
@@ -170,13 +170,22 @@
 
 <script>
 
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['002-001', '002-002', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';
@@ -268,7 +277,7 @@ function updateAppStore() {
         const installAppCheckbox = document.getElementById(appId);
         if (installAppCheckbox) {
             // Assuming installAppCheckbox is an AppCheckbox element
-            installAppCheckbox.checked = installState === 'added';
+            installAppCheckbox.checked = appId === ADD_ICON_ID ? installState !== 'removed' : installState === 'added';
             // You may need to set other properties based on your AppCheckbox implementation
         }
     });

--- a/static/gui/dashboard/002.html
+++ b/static/gui/dashboard/002.html
@@ -170,13 +170,22 @@
 
 <script>
 
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['002-001', '002-002', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';
@@ -268,7 +277,7 @@ function updateAppStore() {
         const installAppCheckbox = document.getElementById(appId);
         if (installAppCheckbox) {
             // Assuming installAppCheckbox is an AppCheckbox element
-            installAppCheckbox.checked = installState === 'added';
+            installAppCheckbox.checked = appId === ADD_ICON_ID ? installState !== 'removed' : installState === 'added';
             // You may need to set other properties based on your AppCheckbox implementation
         }
     });

--- a/static/gui/dashboard/003.html
+++ b/static/gui/dashboard/003.html
@@ -176,13 +176,22 @@ $(function () {
  
 
 <script>
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['003-001', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';

--- a/static/gui/dashboard/004.html
+++ b/static/gui/dashboard/004.html
@@ -165,13 +165,22 @@
 
 <script>
 
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['004-001', '004-002', '004-003', '004-004', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';
@@ -267,7 +276,7 @@ function updateAppStore() {
         const installAppCheckbox = document.getElementById(appId);
         if (installAppCheckbox) {
             // Assuming installAppCheckbox is an AppCheckbox element
-            installAppCheckbox.checked = installState === 'added';
+            installAppCheckbox.checked = appId === ADD_ICON_ID ? installState !== 'removed' : installState === 'added';
             // You may need to set other properties based on your AppCheckbox implementation
         }
     });

--- a/static/gui/dashboard/005.html
+++ b/static/gui/dashboard/005.html
@@ -148,12 +148,20 @@ body:not(.loaded) #slider img {
 <script src="media/js/main.js"></script>
 
 <script>
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
 
-    let allAppIds = ['005-001', '005-002']; // All potential app IDs for this page
-    let appsToDisplay = [];
+    const allAppIds = ['005-001', '005-002']; // All potential app IDs for this page
+    const appsToDisplay = [];
 
     // Add installed apps
     allAppIds.forEach(appId => {
@@ -162,17 +170,16 @@ function updateHomeScreen() {
         }
     });
 
-    // Add the 'Add+' icon last
-    appsToDisplay.push('999-999');
+    if (isAddIconEnabled()) {
+        appsToDisplay.push(ADD_ICON_ID);
+    }
 
     appsToDisplay.forEach(appId => {
         const appElement = document.createElement('a');
         appElement.href = getAppLink(appId); // Set the hyperlink
         appElement.style.cursor = 'pointer';
 
-        let logoFile;
-        // Assuming all logos are .png unless specified otherwise
-        logoFile = `../app-store/apps/${appId}/logo.png`;
+        const logoFile = `../app-store/apps/${appId}/logo.png`;
 
         appElement.innerHTML = `
             <div class="square-${appId}">

--- a/static/gui/dashboard/006-demo.html
+++ b/static/gui/dashboard/006-demo.html
@@ -170,13 +170,22 @@
 
 <script>
 
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['002-001', '002-002', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';
@@ -268,7 +277,7 @@ function updateAppStore() {
         const installAppCheckbox = document.getElementById(appId);
         if (installAppCheckbox) {
             // Assuming installAppCheckbox is an AppCheckbox element
-            installAppCheckbox.checked = installState === 'added';
+            installAppCheckbox.checked = appId === ADD_ICON_ID ? installState !== 'removed' : installState === 'added';
             // You may need to set other properties based on your AppCheckbox implementation
         }
     });

--- a/static/gui/dashboard/006.html
+++ b/static/gui/dashboard/006.html
@@ -170,13 +170,22 @@
 
 <script>
 
+const ADD_ICON_ID = '999-999';
+const ALWAYS_SHOW_ADD_ICON = window.location.pathname.includes('/dashboard/006');
+
+function isAddIconEnabled() {
+    const storedValue = localStorage.getItem(ADD_ICON_ID);
+    return ALWAYS_SHOW_ADD_ICON || storedValue !== 'removed';
+}
+
 function updateHomeScreen() {
     const appsContainer = document.getElementById('apps-container');
     appsContainer.innerHTML = ''; // Clear existing apps
     const appIds = ['006-001', '006-002', '999-999']; // Using class-based IDs
     appIds.forEach(appId => {
         const appInstalled = localStorage.getItem(appId) === 'added';
-        if (appInstalled || appId === '999-999') {
+        const shouldShowApp = appId === ADD_ICON_ID ? isAddIconEnabled() : appInstalled;
+        if (shouldShowApp) {
             const appElement = document.createElement('a');
             appElement.href = getAppLink(appId); // Set the hyperlink
             appElement.style.cursor = 'pointer';
@@ -268,7 +277,7 @@ function updateAppStore() {
         const installAppCheckbox = document.getElementById(appId);
         if (installAppCheckbox) {
             // Assuming installAppCheckbox is an AppCheckbox element
-            installAppCheckbox.checked = installState === 'added';
+            installAppCheckbox.checked = appId === ADD_ICON_ID ? installState !== 'removed' : installState === 'added';
             // You may need to set other properties based on your AppCheckbox implementation
         }
     });


### PR DESCRIPTION
## Summary
- allow the Add+ card toggle to persist across app store pages while keeping the 006 page locked
- read the stored Add+ state on dashboards so the icon hides when toggled off except on dashboard 006
- update the dynamic entertainment catalog page to honour the new Add+ toggle rules

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691069e6c6d08332994d12baf61f80f2)