### PR TITLE
Update PCP menu JSON and add global auth redirect + dynamic sidebar loader

### DIFF
--- a/static/pcp/UI/general.html
+++ b/static/pcp/UI/general.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -2069,6 +2074,86 @@
     </script>
     <!--end::Bootstrap Toasts-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/UI/icons.html
+++ b/static/pcp/UI/icons.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -878,6 +883,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/UI/timeline.html
+++ b/static/pcp/UI/timeline.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -964,6 +969,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/admin/index.html
+++ b/static/pcp/admin/index.html
@@ -5,6 +5,11 @@
   <title>Puck Editor</title>
 </head>
 <body>
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
   <div id="puck-root"></div>
   <script src="./puck.js"></script>
 </body>

--- a/static/pcp/docs/browser-support.html
+++ b/static/pcp/docs/browser-support.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -891,6 +896,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/color-mode.html
+++ b/static/pcp/docs/color-mode.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1211,6 +1216,86 @@
       })();
     </script>
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/components/main-header.html
+++ b/static/pcp/docs/components/main-header.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1274,6 +1279,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/components/main-sidebar.html
+++ b/static/pcp/docs/components/main-sidebar.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -989,6 +994,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/faq.html
+++ b/static/pcp/docs/faq.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -873,6 +878,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/how-to-contribute.html
+++ b/static/pcp/docs/how-to-contribute.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -946,6 +951,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/introduction.html
+++ b/static/pcp/docs/introduction.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -930,6 +935,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/javascript/pushmenu.html
+++ b/static/pcp/docs/javascript/pushmenu.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -871,6 +876,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/javascript/treeview.html
+++ b/static/pcp/docs/javascript/treeview.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -887,6 +892,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/layout.html
+++ b/static/pcp/docs/layout.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -899,6 +904,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/docs/license.html
+++ b/static/pcp/docs/license.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -871,6 +876,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/examples/lockscreen.html
+++ b/static/pcp/examples/lockscreen.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="lockscreen bg-body-secondary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <div class="lockscreen-wrapper">
       <div class="lockscreen-logo">
         <a href="../index2.html"><b>Admin</b>LTE</a>

--- a/static/pcp/examples/login-v2.html
+++ b/static/pcp/examples/login-v2.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="login-page bg-body-secondary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <div class="login-box">
       <div class="card card-outline card-primary">
         <div class="card-header">

--- a/static/pcp/examples/register-v2.html
+++ b/static/pcp/examples/register-v2.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="register-page bg-body-secondary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <div class="register-box">
       <!-- /.register-logo -->
       <div class="card card-outline card-primary">

--- a/static/pcp/examples/register.html
+++ b/static/pcp/examples/register.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="register-page bg-body-secondary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <div class="register-box">
       <div class="register-logo">
         <a href="../index2.html"><b>Admin</b>LTE</a>

--- a/static/pcp/forms/general.html
+++ b/static/pcp/forms/general.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1308,6 +1313,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/generate/theme.html
+++ b/static/pcp/generate/theme.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->

--- a/static/pcp/index.html
+++ b/static/pcp/index.html
@@ -664,5 +664,85 @@
         series: [{ data: [15, 19, 20, 22, 33, 27, 31, 27, 19, 30, 21] }],
       }).render();
     </script>
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
 </html>

--- a/static/pcp/index2.html
+++ b/static/pcp/index2.html
@@ -72,6 +72,11 @@
   </head>
 
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -2026,6 +2031,86 @@
       //-----------------
     </script>
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/index3.html
+++ b/static/pcp/index3.html
@@ -72,6 +72,11 @@
   </head>
 
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1284,6 +1289,86 @@
       sales_chart.render();
     </script>
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/collapsed-sidebar.html
+++ b/static/pcp/layout/collapsed-sidebar.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg sidebar-mini sidebar-collapse bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -889,6 +894,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/fixed-complete.html
+++ b/static/pcp/layout/fixed-complete.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed fixed-header fixed-footer sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -890,6 +895,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/fixed-footer.html
+++ b/static/pcp/layout/fixed-footer.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="fixed-footer sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -888,6 +893,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/fixed-header.html
+++ b/static/pcp/layout/fixed-header.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="fixed-header sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -888,6 +893,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/fixed-sidebar.html
+++ b/static/pcp/layout/fixed-sidebar.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -890,6 +895,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/layout-custom-area.html
+++ b/static/pcp/layout/layout-custom-area.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -929,6 +934,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/layout-rtl.html
+++ b/static/pcp/layout/layout-rtl.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -889,6 +894,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/logo-switch.html
+++ b/static/pcp/layout/logo-switch.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg sidebar-mini bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->

--- a/static/pcp/layout/sidebar-mini.html
+++ b/static/pcp/layout/sidebar-mini.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg sidebar-mini bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -889,6 +894,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/layout/unfixed-sidebar.html
+++ b/static/pcp/layout/unfixed-sidebar.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -888,6 +893,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/menu.json
+++ b/static/pcp/menu.json
@@ -1,127 +1,91 @@
 [
   {
+    "type": "header",
+    "label": "Dashboard"
+  },
+  {
     "type": "item",
-    "label": "Creatives",
-    "icon": "bi-speedometer",
+    "label": "Campaign:1",
+    "icon": "bi-megaphone",
     "open": true,
     "children": [
-      { "label": "Display Ads", "icon": "bi-circle", "href": "#", "active": true },
-      { "label": "Video Ads", "icon": "bi-circle", "href": "#" },
-      { "label": "Animated Ads", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  {
-    "type": "item",
-    "label": "Ads CLI/ API",
-    "icon": "bi-palette",
-    "href": "dist/indexc.html"
-  },
-  {
-    "type": "item",
-    "label": "Widgets",
-    "icon": "bi-box-seam-fill",
-    "children": [
-      { "label": "Small Box", "icon": "bi-circle", "href": "#" },
-      { "label": "Info Box", "icon": "bi-circle", "href": "#" },
-      { "label": "Cards", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  {
-    "type": "item",
-    "label": "Layout Options",
-    "icon": "bi-clipboard-fill",
-    "badge": { "text": "6", "class": "text-bg-secondary" },
-    "children": [
-      { "label": "Beta GUI", "icon": "bi-circle", "href": "#", "action": "loadBetaGui" },
-      { "label": "Fixed Sidebar", "icon": "bi-circle", "href": "#" },
-      { "label": "Fixed Header", "icon": "bi-circle", "href": "#" },
-      { "label": "Fixed Footer", "icon": "bi-circle", "href": "#" },
-      { "label": "Fixed Complete", "icon": "bi-circle", "href": "#" },
-      { "label": "Layout + Custom Area", "icon": "bi-circle", "href": "#" },
-      { "label": "Sidebar Mini", "icon": "bi-circle", "href": "#" },
-      { "label": "Sidebar Mini + Collapsed", "icon": "bi-circle", "href": "#" },
-      { "label": "Sidebar Mini + Logo Switch", "icon": "bi-circle", "href": "#" },
-      { "label": "Layout RTL", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  {
-    "type": "item",
-    "label": "UI Elements",
-    "icon": "bi-tree-fill",
-    "children": [
-      { "label": "General", "icon": "bi-circle", "href": "#" },
-      { "label": "Icons", "icon": "bi-circle", "href": "#" },
-      { "label": "Timeline", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  {
-    "type": "item",
-    "label": "Forms",
-    "icon": "bi-pencil-square",
-    "children": [
-      { "label": "General Elements", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  {
-    "type": "item",
-    "label": "Tables",
-    "icon": "bi-table",
-    "children": [
-      { "label": "Simple Tables", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  { "type": "header", "label": "EXAMPLES" },
-  {
-    "type": "item",
-    "label": "Auth",
-    "icon": "bi-box-arrow-in-right",
-    "children": [
       {
-        "label": "Version 1",
-        "icon": "bi-box-arrow-in-right",
+        "label": "Outlets",
+        "icon": "bi-broadcast",
         "children": [
-          { "label": "Login", "icon": "bi-circle", "href": "#" },
-          { "label": "Register", "icon": "bi-circle", "href": "#" }
+          { "label": "Google", "icon": "bi-circle", "href": "#" },
+          { "label": "TickTock", "icon": "bi-circle", "href": "#" },
+          { "label": "Microsoft", "icon": "bi-circle", "href": "#" },
+          { "label": "Facebook", "icon": "bi-circle", "href": "#" },
+          { "label": "Email", "icon": "bi-circle", "href": "#" },
+          { "label": "ChatGPT(New)", "icon": "bi-circle", "href": "#" }
         ]
       },
       {
-        "label": "Version 2",
-        "icon": "bi-box-arrow-in-right",
+        "label": "Creatives",
+        "icon": "bi-palette",
         "children": [
-          { "label": "Login", "icon": "bi-circle", "href": "#" },
-          { "label": "Register", "icon": "bi-circle", "href": "#" }
+          { "label": "Display", "icon": "bi-circle", "href": "#" },
+          { "label": "Video", "icon": "bi-circle", "href": "#" },
+          { "label": "Animated", "icon": "bi-circle", "href": "#" },
+          { "label": "Text", "icon": "bi-circle", "href": "#" },
+          { "label": "LLM", "icon": "bi-circle", "href": "#" },
+          { "label": "HTML (Email)", "icon": "bi-circle", "href": "#" },
+          { "label": "WebApp", "icon": "bi-circle", "href": "#" }
         ]
-      },
-      { "label": "Lockscreen", "icon": "bi-circle", "href": "#" }
-    ]
-  },
-  { "type": "header", "label": "DOCUMENTATIONS" },
-  { "type": "item", "label": "Installation", "icon": "bi-download", "href": "#" },
-  { "type": "item", "label": "Layout", "icon": "bi-grip-horizontal", "href": "#" },
-  { "type": "item", "label": "Color Mode", "icon": "bi-star-half", "href": "#" },
-  {
-    "type": "item",
-    "label": "Components",
-    "icon": "bi-ui-checks-grid",
-    "children": [
-      { "label": "Main Header", "icon": "bi-circle", "href": "#" },
-      { "label": "Main Sidebar", "icon": "bi-circle", "href": "#" }
+      }
     ]
   },
   {
+    "type": "header",
+    "label": "Tools"
+  },
+  {
     "type": "item",
-    "label": "Javascript",
-    "icon": "bi-filetype-js",
+    "label": "generator",
+    "icon": "bi-wrench-adjustable-circle",
+    "href": "generate/theme.html"
+  },
+  {
+    "type": "header",
+    "label": "Docs"
+  },
+  {
+    "type": "item",
+    "label": "API",
+    "icon": "bi-filetype-json",
+    "href": "docs/introduction.html"
+  },
+  {
+    "type": "item",
+    "label": "SOP",
+    "icon": "bi-journal-check",
+    "href": "docs/layout.html"
+  },
+  {
+    "type": "header",
+    "label": "Release Notes"
+  },
+  {
+    "type": "item",
+    "label": "v0.2",
+    "icon": "bi-tag",
     "children": [
-      { "label": "Treeview", "icon": "bi-circle", "href": "#" }
+      { "label": "mandate", "icon": "bi-circle", "href": "#" },
+      { "label": "brief", "icon": "bi-circle", "href": "#" },
+      { "label": "plan", "icon": "bi-circle", "href": "#" },
+      { "label": "highlight reports", "icon": "bi-circle", "href": "#" }
     ]
   },
-  { "type": "item", "label": "Browser Support", "icon": "bi-browser-edge", "href": "#" },
-  { "type": "item", "label": "How To Contribute", "icon": "bi-hand-thumbs-up-fill", "href": "#" },
-  { "type": "item", "label": "FAQ", "icon": "bi-question-circle-fill", "href": "#" },
-  { "type": "item", "label": "License", "icon": "bi-patch-check-fill", "href": "#" },
-  { "type": "header", "label": "LABELS" },
-  { "type": "item", "label": "Important", "icon": "bi-circle text-danger", "href": "#" },
-  { "type": "item", "label": "Warning", "icon": "bi-circle text-warning", "href": "#" },
-  { "type": "item", "label": "Informational", "icon": "bi-circle text-info", "href": "#" }
+  {
+    "type": "item",
+    "label": "v0.1",
+    "icon": "bi-tag",
+    "children": [
+      { "label": "mandate", "icon": "bi-circle", "href": "#" },
+      { "label": "brief", "icon": "bi-circle", "href": "#" },
+      { "label": "plan", "icon": "bi-circle", "href": "#" },
+      { "label": "highlight reports", "icon": "bi-circle", "href": "#" }
+    ]
+  }
 ]

--- a/static/pcp/tables/simple.html
+++ b/static/pcp/tables/simple.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1187,6 +1192,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/widgets/cards.html
+++ b/static/pcp/widgets/cards.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1108,6 +1113,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/widgets/info-box.html
+++ b/static/pcp/widgets/info-box.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -1181,6 +1186,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>

--- a/static/pcp/widgets/small-box.html
+++ b/static/pcp/widgets/small-box.html
@@ -65,6 +65,11 @@
   <!--end::Head-->
   <!--begin::Body-->
   <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
+    <script>
+      if (localStorage.getItem("authenticated") !== "true") {
+        window.location.href = "/login.html";
+      }
+    </script>
     <!--begin::App Wrapper-->
     <div class="app-wrapper">
       <!--begin::Header-->
@@ -977,6 +982,86 @@
     </script>
     <!--end::OverlayScrollbars Configure-->
     <!--end::Script-->
-  </body>
+      <script>
+      (async function () {
+        const navigation = document.getElementById('navigation');
+        if (!navigation) return;
+
+        const candidates = ['menu.json', '../menu.json', '../../menu.json', '/menu.json'];
+        let menuData = null;
+
+        for (const url of candidates) {
+          try {
+            const response = await fetch(url, { cache: 'no-store' });
+            if (response.ok) {
+              menuData = await response.json();
+              break;
+            }
+          } catch (error) {
+            // ignore and continue with next candidate
+          }
+        }
+
+        if (!menuData) {
+          navigation.innerHTML = '<li class="nav-item"><a href="#" class="nav-link text-danger"><i class="nav-icon bi bi-exclamation-triangle"></i><p>Unable to load menu.json</p></a></li>';
+          return;
+        }
+
+        const currentPath = window.location.pathname.replace(/\/+/g, '/');
+
+        const isActivePath = (href) => {
+          if (!href || href === '#') return false;
+          try {
+            const absolute = new URL(href, window.location.href);
+            return absolute.pathname.replace(/\/+/g, '/') === currentPath;
+          } catch {
+            return false;
+          }
+        };
+
+        const buildMenuHTML = (items = []) =>
+          items
+            .map((item) => {
+              if (item.type === 'header') {
+                return `<li class="nav-header">${item.label}</li>`;
+              }
+
+              const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+              const iconClass = item.icon || 'bi-circle';
+
+              if (hasChildren) {
+                const childHtml = buildMenuHTML(item.children);
+                const isOpen = Boolean(item.open);
+                return `
+                  <li class="nav-item ${isOpen ? 'menu-open' : ''}">
+                    <a href="${item.href || '#'}" class="nav-link ${item.active ? 'active' : ''}">
+                      <i class="nav-icon bi ${iconClass}"></i>
+                      <p>
+                        ${item.label}
+                        ${item.badge ? `<span class="nav-badge badge ${item.badge.class || ''} me-3">${item.badge.text}</span>` : ''}
+                        <i class="nav-arrow bi bi-chevron-right"></i>
+                      </p>
+                    </a>
+                    <ul class="nav nav-treeview">${childHtml}</ul>
+                  </li>
+                `;
+              }
+
+              const active = item.active || isActivePath(item.href);
+              return `
+                <li class="nav-item">
+                  <a href="${item.href || '#'}" class="nav-link ${active ? 'active' : ''}">
+                    <i class="nav-icon bi ${iconClass}"></i>
+                    <p>${item.label}</p>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+
+        navigation.innerHTML = buildMenuHTML(menuData);
+      })();
+    </script>
+</body>
   <!--end::Body-->
 </html>


### PR DESCRIPTION
### Motivation
- Standardize the PCP sidebar to use a single JSON-driven menu and update the menu structure to the provided Dashboard / Campaign:1 / Tools / Docs / Release Notes hierarchy.
- Enforce a consistent authentication flow so all pages default to redirecting unauthenticated users to `login.html`.
- Replace duplicated hardcoded sidebar markup with a shared dynamic loader so pages render the menu from `menu.json` and stay in sync.

### Description
- Replaced `static/pcp/menu.json` with the revised structure (adds `Dashboard` header; `Campaign:1` with `Outlets` and `Creatives` subtrees; `Tools` → `generator`; `Docs` → `API`/`SOP`; `Release Notes` → `v0.2`/`v0.1` items).
- Injected an auth check snippet on all non-login PCP HTML pages that redirects to `/login.html` when `localStorage.getItem("authenticated") !== "true"`.
- Added a client-side dynamic menu loader to pages that contain the sidebar `#navigation` which attempts to fetch `menu.json` from multiple relative locations, falls back to an error message if not found, and renders nested menus (headers/items/children/badges/active state) with `buildMenuHTML`.
- Applied the auth + menu-loader changes across the PCP app HTML files (multiple `index`, `layout`, `docs`, `widgets`, `examples`, `forms`, `tables`, `UI`, etc.) so the behavior is consistent site-wide.

### Testing
- Verified `menu.json` parses as valid JSON using `python` and the file at `static/pcp/menu.json` returned no parse errors (success).
- Ran repository-wide checks with small `python` scripts that confirmed every non-login HTML page contains the auth redirect snippet and every page with `id="navigation"` includes the dynamic menu loader injection (both checks returned zero missing files, success).
- Attempted a browser-based end-to-end check using Playwright to sign in and capture a screenshot, but Chromium crashed in this environment (SIGSEGV) so the headless screenshot step failed; the failure is environmental and not related to the menu/auth changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d03676ec832087a4649ec48f4eb8)