### PR TITLE
release: v0.1.0.08 — parent/child chat routing and in-site WhatsApp chat modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [financecheque-v0.1.0.08] - 2026-05-10
+
+### Added
+- Parent proxy chat routing endpoint via `/api/proxy?action=chat` that forwards chat prompts to the least-loaded live child proxy.
+- Child proxy `/chat` endpoint in `child-proxy.js` so parent-routed chat requests can be fulfilled by the Hermes/Kiro worker host.
+- WhatsApp icon modal now opens a real in-site chat box that posts to the parent proxy and shows child-proxy responses.
+
+### Changed
+- Version bump to `0.1.0.08` for a new semantic release.
+
+---
+
 ## [financecheque-v0.1.0.07] - 2026-05-10
 
 ### Added
@@ -145,4 +157,3 @@ All notable changes to this project will be documented in this file.
 - Cloudflare Pages deployment configuration
 - £ symbol replaced with "credits" throughout
 - "Lead Buyer" and "Lead Seller(s)" labels updated
-

--- a/child-proxy.js
+++ b/child-proxy.js
@@ -69,6 +69,18 @@ app.get("/health", (_req, res) => {
   res.json({ ok: true, childId: CHILD_ID, activeJobs });
 });
 
+app.post("/chat", async (req, res) => {
+  const { message } = req.body || {};
+  if (!message) return res.status(400).json({ ok: false, error: "message is required" });
+
+  try {
+    const reply = await runChat(message);
+    return res.json({ ok: true, reply, childId: CHILD_ID });
+  } catch (error) {
+    return res.status(500).json({ ok: false, error: error.message || "chat failed", childId: CHILD_ID });
+  }
+});
+
 // ── Run job via Hermes/Kiro ───────────────────────────────────────────────
 async function runJob(job) {
   const { id, url, leadAmount, quantity } = job;
@@ -125,6 +137,21 @@ function buildPrompt(url, leadAmount, quantity) {
     `5. Output a structured report with all assets ready to deploy.`,
     `Be concise and output actionable deliverables only.`,
   ].join("\n");
+}
+
+async function runChat(message) {
+  const prompt = `You are the FinanceCheque child proxy Hermes operator. Reply concisely.\nUser message: ${message}`;
+  const kiroPath = process.env.KIRO_PATH || "/home/ubuntu/kiro-cli-temp";
+
+  try {
+    const { stdout } = await execFileAsync(kiroPath, ["chat", "--non-interactive", "--message", prompt], {
+      timeout: 120_000,
+      maxBuffer: 1024 * 1024,
+    });
+    if (stdout?.trim()) return stdout.trim();
+  } catch {}
+
+  return `Child proxy ${CHILD_ID} received your message and is online.`;
 }
 
 // ── Start ─────────────────────────────────────────────────────────────────

--- a/functions/api/proxy.ts
+++ b/functions/api/proxy.ts
@@ -27,6 +27,40 @@ export async function onRequestPost(context: { request: Request; env: Env }) {
     return json({ ok: true });
   }
 
+  if (action === 'chat') {
+    const { message, sessionId } = body;
+    if (!message || typeof message !== 'string') return json({ error: 'message is required' }, 400);
+
+    const child = await env.DB.prepare(
+      "SELECT id, url FROM child_proxies WHERE last_seen > datetime('now', '-60 seconds') ORDER BY load ASC, last_seen DESC LIMIT 1"
+    ).first() as any;
+
+    if (!child) {
+      return json({
+        ok: false,
+        error: 'No child proxies are currently online.',
+      }, 503);
+    }
+
+    try {
+      const resp = await fetch(`${child.url}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, sessionId }),
+      });
+
+      const data = await resp.json().catch(() => ({}));
+      return json({
+        ok: resp.ok,
+        routedTo: child.id,
+        childUrl: child.url,
+        ...data,
+      }, resp.ok ? 200 : 502);
+    } catch (error: any) {
+      return json({ ok: false, error: error?.message || 'Child proxy unreachable' }, 502);
+    }
+  }
+
   return json({ error: 'Unknown action' }, 400);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "0.1.0.07",
+  "version": "0.1.0.08",
   "type": "module",
   "scripts": {
     "dev": "tsx server.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,9 @@ export default function App() {
   const [demoOrientation, setDemoOrientation] = useState<'portrait' | 'landscape'>('portrait');
   const [isWalletMenuOpen, setIsWalletMenuOpen] = useState(false);
   const [showContactModal, setShowContactModal] = useState(false);
+  const [chatMessage, setChatMessage] = useState('');
+  const [chatReply, setChatReply] = useState('');
+  const [isChatting, setIsChatting] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showConnectionsModal, setShowConnectionsModal] = useState(false);
@@ -1129,27 +1132,56 @@ export default function App() {
             exit={{ opacity: 0 }}
             className="fixed top-[106px] left-0 right-0 bottom-0 z-[1000] flex items-start justify-center p-6 bg-black/80 backdrop-blur-md overflow-y-auto"
           >
-            <motion.div 
+            <motion.div
               initial={{ y: 20, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
-              className="w-full max-w-sm bg-paper border border-border p-10 space-y-8 shadow-2xl frame text-center my-8"
+              className="w-full max-w-md bg-paper border border-border p-8 space-y-6 shadow-2xl frame my-8"
             >
-              <div className="flex flex-col items-center gap-4">
-                <div className="w-16 h-16 bg-accent/10 text-accent flex items-center justify-center rounded-full">
-                  <User size={32} />
-                </div>
-                <h3 className="text-xl font-bold text-ink">Sign in to speak to your free agent</h3>
+              <div className="flex flex-col items-center gap-3 text-center">
+                <img src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg" alt="WhatsApp" className="w-10 h-10" />
+                <h3 className="text-xl font-bold text-ink">Chat with Agent Network</h3>
+                <p className="text-xs text-ink/50">Routes via financecheque.uk parent proxy to active child proxies.</p>
               </div>
-              <button 
-                onClick={() => {
-                  setShowContactModal(false);
-                  setAuthModalTab('signin');
-                  setShowAuthModal(true);
-                }}
-                className="w-full bg-ink text-paper font-bold py-4 uppercase tracking-widest text-xs hover:bg-accent transition-all"
-              >
-                Sign In / Register
-              </button>
+              <div className="space-y-3">
+                <textarea
+                  value={chatMessage}
+                  onChange={(e) => setChatMessage(e.target.value)}
+                  placeholder="Type your message..."
+                  className="w-full border border-border bg-card p-3 text-sm min-h-28"
+                />
+                {chatReply && <div className="text-xs bg-card border border-border p-3 whitespace-pre-wrap">{chatReply}</div>}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowContactModal(false)}
+                  className="flex-1 border border-border py-3 text-xs font-bold uppercase tracking-widest"
+                >
+                  Close
+                </button>
+                <button
+                  disabled={isChatting || !chatMessage.trim()}
+                  onClick={async () => {
+                    setIsChatting(true);
+                    setChatReply('');
+                    try {
+                      const resp = await fetch('/api/proxy?action=chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ message: chatMessage.trim(), sessionId: 'web-whatsapp' }),
+                      });
+                      const data = await resp.json();
+                      setChatReply(data.reply || data.error || 'No response');
+                    } catch {
+                      setChatReply('Unable to reach parent proxy.');
+                    } finally {
+                      setIsChatting(false);
+                    }
+                  }}
+                  className="flex-1 bg-ink text-paper py-3 text-xs font-bold uppercase tracking-widest hover:bg-accent disabled:opacity-50"
+                >
+                  {isChatting ? 'Sending...' : 'Send'}
+                </button>
+              </div>
             </motion.div>
           </motion.div>
         )}


### PR DESCRIPTION
### Motivation
- Wire the web UI WhatsApp-style contact button into the parent/child proxy control plane so website users can chat with an available child proxy agent. 
- Provide a minimal backend plumbing that forwards chat messages from the parent proxy to registered child proxies and returns their replies, enabling operator interaction and testing of the agent network.

### Description
- Added a parent-proxy chat routing action in `functions/api/proxy.ts` at `POST /api/proxy?action=chat` which selects the least-loaded live child proxy, forwards the request to that child’s `/chat` endpoint, and returns the routed response and metadata. 
- Implemented a `/chat` endpoint in `child-proxy.js` that runs `runChat()` to attempt a reply via the configured Kiro CLI (with a graceful fallback message if Kiro is unavailable). 
- Replaced the previous WhatsApp prompt modal with an interactive in-site chat UI in `src/App.tsx` that posts typed messages to the parent proxy and displays replies inline. 
- Bumped the package version to `0.1.0.08` in `package.json` and added the `financecheque-v0.1.0.08` entry to `CHANGELOG.md`. 
- Note: this change wires the chat/control plane paths; the full installer bootstrap that installs Hermes/Kiro/other CLIs and configures the local web GUI end-to-end was not replaced or reworked here.

### Testing
- Ran the TypeScript lint step via `npm run lint`, which failed due to pre-existing vendored JS assets being included in the TypeScript compile scope (errors in `public/ui/dashboard/js/jquery-3.3.1.js` and `public/ui/dashboard/js/search/test.js`), and those failures are unrelated to the changes in this PR. 
- Verified locally that modified Node/Express child proxy code exposes `/health`, `/dispatch`, and the new `/chat` endpoint and that the parent function forwards requests to a reachable child proxy (manual invocation exercised in the development environment). 
- Did not run an end-to-end Cloudflare Pages deployment from this environment, so production deployment must occur by pushing this branch to GitHub and letting your existing Cloudflare pipeline deploy it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cc427b1c83209ba6582bca4309ae)