### PR TITLE
Rewrite App to local-first contact debt tracker with 3-party cycle detection and import/export

### DIFF
--- a/static/codex_create-debt-cancellation-circle-app/AGENT.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/AGENT.high.md
@@ -1,0 +1,9 @@
+# AGENT.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/AGENT.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/AGENT.left.md
@@ -1,0 +1,9 @@
+# AGENT.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/AGENT.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/AGENT.low.md
@@ -1,0 +1,9 @@
+# AGENT.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/AGENT.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/AGENT.right.md
@@ -1,0 +1,9 @@
+# AGENT.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CHANGELOG.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/CHANGELOG.high.md
@@ -1,0 +1,9 @@
+# CHANGELOG.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CHANGELOG.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/CHANGELOG.left.md
@@ -1,0 +1,9 @@
+# CHANGELOG.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CHANGELOG.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/CHANGELOG.low.md
@@ -1,0 +1,9 @@
+# CHANGELOG.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CHANGELOG.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/CHANGELOG.right.md
@@ -1,0 +1,9 @@
+# CHANGELOG.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CONTEXT.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/CONTEXT.high.md
@@ -1,0 +1,9 @@
+# CONTEXT.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CONTEXT.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/CONTEXT.left.md
@@ -1,0 +1,9 @@
+# CONTEXT.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CONTEXT.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/CONTEXT.low.md
@@ -1,0 +1,9 @@
+# CONTEXT.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/CONTEXT.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/CONTEXT.right.md
@@ -1,0 +1,9 @@
+# CONTEXT.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.high.md
@@ -1,0 +1,9 @@
+# MASTERPLAN.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.left.md
@@ -1,0 +1,9 @@
+# MASTERPLAN.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.low.md
@@ -1,0 +1,9 @@
+# MASTERPLAN.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/MASTERPLAN.right.md
@@ -1,0 +1,9 @@
+# MASTERPLAN.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MEMORY.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/MEMORY.high.md
@@ -1,0 +1,9 @@
+# MEMORY.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MEMORY.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/MEMORY.left.md
@@ -1,0 +1,9 @@
+# MEMORY.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MEMORY.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/MEMORY.low.md
@@ -1,0 +1,9 @@
+# MEMORY.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/MEMORY.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/MEMORY.right.md
@@ -1,0 +1,9 @@
+# MEMORY.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/NOTES.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/NOTES.high.md
@@ -1,0 +1,9 @@
+# NOTES.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/NOTES.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/NOTES.left.md
@@ -1,0 +1,9 @@
+# NOTES.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/NOTES.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/NOTES.low.md
@@ -1,0 +1,9 @@
+# NOTES.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/NOTES.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/NOTES.right.md
@@ -1,0 +1,9 @@
+# NOTES.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PLAN.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/PLAN.high.md
@@ -1,0 +1,9 @@
+# PLAN.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PLAN.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/PLAN.left.md
@@ -1,0 +1,9 @@
+# PLAN.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PLAN.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/PLAN.low.md
@@ -1,0 +1,9 @@
+# PLAN.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PLAN.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/PLAN.right.md
@@ -1,0 +1,9 @@
+# PLAN.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PROMPT.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/PROMPT.high.md
@@ -1,0 +1,9 @@
+# PROMPT.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PROMPT.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/PROMPT.left.md
@@ -1,0 +1,9 @@
+# PROMPT.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PROMPT.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/PROMPT.low.md
@@ -1,0 +1,9 @@
+# PROMPT.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/PROMPT.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/PROMPT.right.md
@@ -1,0 +1,9 @@
+# PROMPT.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/README.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/README.high.md
@@ -1,0 +1,9 @@
+# README.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/README.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/README.left.md
@@ -1,0 +1,9 @@
+# README.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/README.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/README.low.md
@@ -1,0 +1,9 @@
+# README.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/README.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/README.right.md
@@ -1,0 +1,9 @@
+# README.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RECIPE.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/RECIPE.high.md
@@ -1,0 +1,9 @@
+# RECIPE.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RECIPE.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/RECIPE.left.md
@@ -1,0 +1,9 @@
+# RECIPE.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RECIPE.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/RECIPE.low.md
@@ -1,0 +1,9 @@
+# RECIPE.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RECIPE.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/RECIPE.right.md
@@ -1,0 +1,9 @@
+# RECIPE.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/REFERENCE.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/REFERENCE.high.md
@@ -1,0 +1,9 @@
+# REFERENCE.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/REFERENCE.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/REFERENCE.left.md
@@ -1,0 +1,9 @@
+# REFERENCE.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/REFERENCE.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/REFERENCE.low.md
@@ -1,0 +1,9 @@
+# REFERENCE.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/REFERENCE.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/REFERENCE.right.md
@@ -1,0 +1,9 @@
+# REFERENCE.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RULES.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/RULES.high.md
@@ -1,0 +1,9 @@
+# RULES.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RULES.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/RULES.left.md
@@ -1,0 +1,9 @@
+# RULES.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RULES.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/RULES.low.md
@@ -1,0 +1,9 @@
+# RULES.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/RULES.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/RULES.right.md
@@ -1,0 +1,9 @@
+# RULES.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/SCHEMA.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/SCHEMA.high.md
@@ -1,0 +1,9 @@
+# SCHEMA.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/SCHEMA.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/SCHEMA.left.md
@@ -1,0 +1,9 @@
+# SCHEMA.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/SCHEMA.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/SCHEMA.low.md
@@ -1,0 +1,9 @@
+# SCHEMA.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/SCHEMA.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/SCHEMA.right.md
@@ -1,0 +1,9 @@
+# SCHEMA.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/STYLE.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/STYLE.high.md
@@ -1,0 +1,9 @@
+# STYLE.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/STYLE.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/STYLE.left.md
@@ -1,0 +1,9 @@
+# STYLE.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/STYLE.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/STYLE.low.md
@@ -1,0 +1,9 @@
+# STYLE.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/STYLE.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/STYLE.right.md
@@ -1,0 +1,9 @@
+# STYLE.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/TEMPLATE.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/TEMPLATE.high.md
@@ -1,0 +1,9 @@
+# TEMPLATE.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/TEMPLATE.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/TEMPLATE.left.md
@@ -1,0 +1,9 @@
+# TEMPLATE.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/TEMPLATE.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/TEMPLATE.low.md
@@ -1,0 +1,9 @@
+# TEMPLATE.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/TEMPLATE.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/TEMPLATE.right.md
@@ -1,0 +1,9 @@
+# TEMPLATE.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/WING.high.md
+++ b/static/codex_create-debt-cancellation-circle-app/WING.high.md
@@ -1,0 +1,9 @@
+# WING.high.md
+
+## Steering Block
+steering block #C490D1 at top
+
+Branch: **codex**
+Color: #C490D1
+Position: top
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/WING.left.md
+++ b/static/codex_create-debt-cancellation-circle-app/WING.left.md
@@ -1,0 +1,9 @@
+# WING.left.md
+
+## Steering Block
+steering block #C490D1 at left
+
+Branch: **codex**
+Color: #C490D1
+Position: left
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/WING.low.md
+++ b/static/codex_create-debt-cancellation-circle-app/WING.low.md
@@ -1,0 +1,9 @@
+# WING.low.md
+
+## Steering Block
+steering block #C490D1 at bottom
+
+Branch: **codex**
+Color: #C490D1
+Position: bottom
+Joystick Direction: codex

--- a/static/codex_create-debt-cancellation-circle-app/WING.right.md
+++ b/static/codex_create-debt-cancellation-circle-app/WING.right.md
@@ -1,0 +1,9 @@
+# WING.right.md
+
+## Steering Block
+steering block #C490D1 at right
+
+Branch: **codex**
+Color: #C490D1
+Position: right
+Joystick Direction: codex

--- a/static/dcc/App.tsx
+++ b/static/dcc/App.tsx
@@ -1,282 +1,164 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import {
-  PlusIcon,
-  ArrowPathIcon,
-  WalletIcon,
-  Cog6ToothIcon,
-  InformationCircleIcon,
-  ShieldCheckIcon,
-  XMarkIcon,
-  LockClosedIcon
-} from '@heroicons/react/24/outline';
+import React, { useEffect, useMemo, useState } from 'react';
 
-import { 
-  Transaction, 
-  TransactionType, 
-  TransactionStatus, 
-  UserSettings, 
-  Payload, 
-  LedgerStats 
-} from './types';
+type ContactDebt = {
+  id: string;
+  name: string;
+  email: string;
+  theyOweMeGbp: number;
+  iOweThemGbp: number;
+};
 
-import { 
-  getTransactions, 
-  saveTransactions, 
-  getSettings, 
-  saveSettings, 
-  generateWalletUid 
-} from './utils/storage';
+type Edge = { from: string; to: string; amount: number };
 
-import { 
-  getPayloadFromUrl, 
-  clearUrlHash, 
-  generateDccUrl 
-} from './utils/crypto';
+const STORAGE_KEY = 'dcc-circle-cache-v1';
 
-import { fetchExchangeRates, ExchangeRates } from './services/exchangeRateService';
-
-// Components
-import Dashboard from './components/Dashboard';
-import TransactionList from './components/TransactionList';
-import TransactionForm from './components/TransactionForm';
-import LinkProcessor from './components/LinkProcessor';
-import ImportTool from './components/ImportTool';
-import LandingPage from './components/LandingPage';
+const cleanMoney = (value: number) => {
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.round(value * 100) / 100);
+};
 
 const App: React.FC = () => {
-  const [view, setView] = useState<'landing' | 'app'>('landing');
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [settings, setSettings] = useState<UserSettings>(getSettings());
-  const [activeTab, setActiveTab] = useState<'balances' | 'history' | 'settings' | 'import'>('balances');
-  const [incomingPayload, setIncomingPayload] = useState<Payload | null>(null);
-  const [showForm, setShowForm] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [rates, setRates] = useState<ExchangeRates>({ USD: 1 });
-  const [showPrivacyNotice, setShowPrivacyNotice] = useState(true);
+  const [rows, setRows] = useState<ContactDebt[]>([]);
+  const [form, setForm] = useState({ name: '', email: '', theyOweMeGbp: '', iOweThemGbp: '' });
+  const [importText, setImportText] = useState('');
 
   useEffect(() => {
-    setTransactions(getTransactions());
-
-    const payload = getPayloadFromUrl();
-    if (payload) {
-      setIncomingPayload(payload);
-      setView('app'); // Auto-switch to app if link detected
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as ContactDebt[];
+      if (Array.isArray(parsed)) setRows(parsed);
+    } catch {
+      // ignore invalid cache
     }
-
-    // Migration/Ensure UID exists
-    if (!settings.walletUid) {
-      const newSettings = { ...settings, walletUid: generateWalletUid() };
-      setSettings(newSettings);
-      saveSettings(newSettings);
-    }
-
-    // Initial rates fetch
-    fetchExchangeRates().then(setRates);
   }, []);
 
   useEffect(() => {
-    saveTransactions(transactions);
-  }, [transactions]);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(rows));
+  }, [rows]);
 
-  useEffect(() => {
-    saveSettings(settings);
-  }, [settings]);
+  const exportedBase64 = useMemo(() => btoa(unescape(encodeURIComponent(JSON.stringify(rows)))), [rows]);
 
-  const stats: LedgerStats = useMemo(() => {
-    const balances: Record<string, { confirmedNet: number; proposedInbound: number; proposedOutbound: number }> = {};
+  const edges = useMemo<Edge[]>(() => {
+    const result: Edge[] = [];
+    for (const row of rows) {
+      if (row.iOweThemGbp > 0) result.push({ from: 'me', to: row.email.toLowerCase(), amount: row.iOweThemGbp });
+      if (row.theyOweMeGbp > 0) result.push({ from: row.email.toLowerCase(), to: 'me', amount: row.theyOweMeGbp });
+    }
+    return result;
+  }, [rows]);
 
-    transactions.forEach(t => {
-      const cur = t.currency || 'USD';
-      if (!balances[cur]) {
-        balances[cur] = { confirmedNet: 0, proposedInbound: 0, proposedOutbound: 0 };
-      }
+  const circleSuggestions = useMemo(() => {
+    const suggestions: Array<{ a: string; b: string; c: string; cancellable: number }> = [];
+    const byFrom = new Map<string, Edge[]>();
+    edges.forEach(e => byFrom.set(e.from, [...(byFrom.get(e.from) || []), e]));
 
-      if (t.status === TransactionStatus.CONFIRMED) {
-        if (t.type === TransactionType.UOM) {
-          balances[cur].confirmedNet += t.amount;
-        } else {
-          balances[cur].confirmedNet -= t.amount;
+    const meOut = byFrom.get('me') || [];
+    for (const e1 of meOut) {
+      const b = e1.to;
+      const bOut = byFrom.get(b) || [];
+      for (const e2 of bOut) {
+        const c = e2.to;
+        if (c === 'me' || c === b) continue;
+        const cOut = byFrom.get(c) || [];
+        const e3 = cOut.find(x => x.to === 'me');
+        if (!e3) continue;
+        const cancellable = cleanMoney(Math.min(e1.amount, e2.amount, e3.amount));
+        if (cancellable > 0) {
+          suggestions.push({ a: b, b: c, c: 'me', cancellable });
         }
-      } else if (t.status === TransactionStatus.PENDING) {
-        if (t.type === TransactionType.UOM) {
-          balances[cur].proposedInbound += t.amount;
-        } else {
-          balances[cur].proposedOutbound += t.amount;
-        }
       }
+    }
+
+    const unique = new Map<string, { a: string; b: string; c: string; cancellable: number }>();
+    suggestions.forEach(s => {
+      const key = [s.a, s.b].sort().join('|');
+      const prev = unique.get(key);
+      if (!prev || s.cancellable > prev.cancellable) unique.set(key, s);
     });
+    return [...unique.values()].sort((x, y) => y.cancellable - x.cancellable);
+  }, [edges]);
 
-    return { balances };
-  }, [transactions]);
-
-  const handleAddTransaction = (newTx: Transaction) => {
-    setTransactions(prev => [newTx, ...prev]);
-    setShowForm(false);
+  const addRow = () => {
+    if (!form.name.trim() || !form.email.trim()) return;
+    const newRow: ContactDebt = {
+      id: crypto.randomUUID(),
+      name: form.name.trim(),
+      email: form.email.trim().toLowerCase(),
+      theyOweMeGbp: cleanMoney(Number(form.theyOweMeGbp || 0)),
+      iOweThemGbp: cleanMoney(Number(form.iOweThemGbp || 0))
+    };
+    setRows(prev => [newRow, ...prev]);
+    setForm({ name: '', email: '', theyOweMeGbp: '', iOweThemGbp: '' });
   };
 
-  const handleUpdateStatus = (id: string, status: TransactionStatus, counterpartyUid?: string) => {
-    setTransactions(prev => prev.map(t =>
-      t.id === id ? {
-        ...t,
-        status,
-        updatedAt: Date.now(),
-        counterpartyWalletUid: counterpartyUid || t.counterpartyWalletUid
-      } : t
-    ));
-  };
-
-  const handleDeleteTransaction = (id: string) => {
-    if (confirm("Delete this record permanently?")) {
-      setTransactions(prev => prev.filter(t => t.id !== id));
+  const importData = () => {
+    try {
+      const decoded = decodeURIComponent(escape(atob(importText.trim())));
+      const parsed = JSON.parse(decoded) as ContactDebt[];
+      if (!Array.isArray(parsed)) throw new Error('Invalid format');
+      setRows(parsed.map(item => ({ ...item, id: item.id || crypto.randomUUID() })));
+      setImportText('');
+      alert('Imported successfully');
+    } catch {
+      alert('Import failed. Please check the base64 string.');
     }
   };
 
-  const handleAcceptIncoming = async (payload: Payload) => {
-    setIsProcessing(true);
-
-    const newTx: Transaction = {
-      id: crypto.randomUUID(),
-      type: payload.data.type === TransactionType.IOU ? TransactionType.UOM : TransactionType.IOU,
-      amount: payload.data.amount || 0,
-      currency: payload.data.currency || 'USD',
-      counterpartyEmail: payload.senderEmail,
-      counterpartyWalletUid: payload.senderWalletUid,
-      status: TransactionStatus.CONFIRMED,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      originDate: payload.data.originDate || new Date().toISOString().split('T')[0],
-      reference: payload.data.reference || '',
-      isOriginator: false,
-      relatedTransactionId: payload.data.id
-    };
-
-    setTransactions(prev => [newTx, ...prev]);
-
-    const responsePayload: Payload = {
-      type: 'RESPONSE',
-      data: { ...newTx, status: TransactionStatus.CONFIRMED },
-      senderEmail: settings.email,
-      senderWalletUid: settings.walletUid,
-      timestamp: Date.now()
-    };
-
-    const confirmUrl = generateDccUrl(responsePayload);
-
-    // Clean email template using array + join
-    const emailBody = [
-      "DCC Acceptance Confirmation",
-      "",
-      "Hi,",
-      "",
-      `I have accepted your ${newTx.type} request for ${newTx.amount} ${newTx.currency}`,
-      `Reference: ${newTx.reference || '(none)'}`,
-      `Original date: ${newTx.originDate}`,
-      "",
-      "My confirmation link (please open in browser to record the mutual agreement):",
-      confirmUrl,
-      "",
-      "Best regards,",
-      settings.email || 'DCC User'
-    ].join('\n');
-
-    const subject = `DCC Accepted: ${newTx.type} - Ref: ${newTx.reference || 'No ref'}`;
-
-    const gmailUrl = `https://mail.google.com/mail/u/0/?view=cm&fs=1&to=${encodeURIComponent(payload.senderEmail)}&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(emailBody)}&bcc=dcc@datro.xyz`;
-
-    window.open(gmailUrl, '_blank');
-
-    setIncomingPayload(null);
-    clearUrlHash();
-    setIsProcessing(false);
-  };
-
   return (
-    <div className="min-h-screen bg-slate-50 font-sans">
-      {/* Landing Page */}
-      {view === 'landing' && (
-        <LandingPage onLaunch={() => setView('app')} />
-      )}
+    <div className="min-h-screen bg-slate-50 text-slate-900 p-6">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold">DCC — Debt Cancellation Circle</h1>
+        <p className="text-sm text-slate-600">Track debts in GBP, cached in your browser. Export/import as base64 to share by email.</p>
 
-      {/* Main App View */}
-      {view === 'app' && (
-        <>
-          {/* Header / Navigation */}
-          <header className="bg-white border-b border-slate-200 sticky top-0 z-10 shadow-sm">
-            <div className="max-w-5xl mx-auto px-4 py-4 flex justify-between items-center">
-              <h1 className="text-2xl font-bold text-slate-800">DCC Ledger</h1>
-              <nav className="flex gap-6">
-                <button
-                  onClick={() => setActiveTab('balances')}
-                  className={`font-medium ${activeTab === 'balances' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-600 hover:text-indigo-600'}`}
-                >
-                  Balances
-                </button>
-                <button
-                  onClick={() => setActiveTab('history')}
-                  className={`font-medium ${activeTab === 'history' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-600 hover:text-indigo-600'}`}
-                >
-                  History
-                </button>
-                <button
-                  onClick={() => setActiveTab('settings')}
-                  className={`font-medium ${activeTab === 'settings' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-600 hover:text-indigo-600'}`}
-                >
-                  Settings
-                </button>
-                <button
-                  onClick={() => setActiveTab('import')}
-                  className={`font-medium ${activeTab === 'import' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-600 hover:text-indigo-600'}`}
-                >
-                  Import
-                </button>
-              </nav>
-            </div>
-          </header>
+        <section className="bg-white rounded-xl shadow p-4 grid gap-3 md:grid-cols-5">
+          <input className="border p-2 rounded" placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
+          <input className="border p-2 rounded" placeholder="Email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+          <input className="border p-2 rounded" type="number" min="0" step="0.01" placeholder="They owe me (£)" value={form.theyOweMeGbp} onChange={e => setForm({ ...form, theyOweMeGbp: e.target.value })} />
+          <input className="border p-2 rounded" type="number" min="0" step="0.01" placeholder="I owe them (£)" value={form.iOweThemGbp} onChange={e => setForm({ ...form, iOweThemGbp: e.target.value })} />
+          <button className="bg-indigo-600 text-white rounded px-3 py-2" onClick={addRow}>Add</button>
+        </section>
 
-          {/* Main Content */}
-          <main className="max-w-5xl mx-auto px-4 py-8">
-            {activeTab === 'balances' && (
-              <Dashboard 
-                stats={stats} 
-                rates={rates} 
-                transactions={transactions} 
-                onAddRequest={() => setShowForm(true)} 
-              />
-            )}
+        <section className="bg-white rounded-xl shadow p-4">
+          <h2 className="font-semibold mb-3">People & Debts</h2>
+          <div className="overflow-auto">
+            <table className="w-full text-sm">
+              <thead><tr className="text-left border-b"><th>Name</th><th>Email</th><th>They owe me</th><th>I owe them</th><th></th></tr></thead>
+              <tbody>
+                {rows.map(r => (
+                  <tr key={r.id} className="border-b">
+                    <td className="py-2">{r.name}</td><td>{r.email}</td><td>£{r.theyOweMeGbp.toFixed(2)}</td><td>£{r.iOweThemGbp.toFixed(2)}</td>
+                    <td><button className="text-red-600" onClick={() => setRows(prev => prev.filter(x => x.id !== r.id))}>Remove</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-            {activeTab === 'history' && (
-              <TransactionList 
-                transactions={transactions}
-                onDelete={handleDeleteTransaction}
-                onUpdateStatus={handleUpdateStatus}
-              />
-            )}
-
-            {activeTab === 'settings' && (
-              <div className="max-w-lg mx-auto bg-white p-8 rounded-xl shadow">
-                <h2 className="text-xl font-bold mb-6">Settings</h2>
-                {/* Add your settings form here */}
-              </div>
-            )}
-
-            {activeTab === 'import' && <ImportTool />}
-          </main>
-
-          {/* Footer */}
-          <footer className="bg-slate-100 py-6 text-center text-slate-500 text-sm">
-            © 2025 Debt Cancellation Circle • Local-first • Peer-to-peer
-          </footer>
-
-          {/* Transaction Form Modal */}
-          {showForm && (
-            <TransactionForm
-              onClose={() => setShowForm(false)}
-              onSubmit={handleAddTransaction}
-              userSettings={settings}
-            />
+        <section className="bg-white rounded-xl shadow p-4">
+          <h2 className="font-semibold mb-2">Debt Cancellation Circles (3-party)</h2>
+          {circleSuggestions.length === 0 ? (
+            <p className="text-sm text-slate-600">No cancellable circles found yet.</p>
+          ) : (
+            <ul className="list-disc pl-5 text-sm space-y-1">
+              {circleSuggestions.map((c, i) => (
+                <li key={i}>
+                  You owe <b>{c.a}</b>, <b>{c.a}</b> owes <b>{c.b}</b>, and <b>{c.b}</b> owes you. Maximum cancellable amount: <b>£{c.cancellable.toFixed(2)}</b>.
+                </li>
+              ))}
+            </ul>
           )}
-        </>
-      )}
+        </section>
+
+        <section className="bg-white rounded-xl shadow p-4 space-y-3">
+          <h2 className="font-semibold">Export / Import</h2>
+          <textarea className="w-full border rounded p-2 h-28" value={exportedBase64} readOnly />
+          <button className="border rounded px-3 py-2" onClick={() => navigator.clipboard.writeText(exportedBase64)}>Copy export string</button>
+          <textarea className="w-full border rounded p-2 h-28" placeholder="Paste base64 string to import" value={importText} onChange={e => setImportText(e.target.value)} />
+          <button className="bg-emerald-600 text-white rounded px-3 py-2" onClick={importData}>Import data</button>
+        </section>
+      </div>
     </div>
   );
 };

--- a/static/dcc/README.md
+++ b/static/dcc/README.md
@@ -1,2 +1,56 @@
-Debt Cancellation Circle - docs
-Test Test
+# DCC Tech App
+
+DCC Tech App is a local-first web application for managing contact-based debt balances in GBP and spotting cancellable debt circles.
+
+## Core features
+
+- Contact ledger with per-person fields:
+  - `name`
+  - `email`
+  - `theyOweMeGbp`
+  - `iOweThemGbp`
+- Client-side persistence with browser `localStorage` (`dcc-circle-cache-v1`).
+- Base64 export of the full dataset for sharing.
+- Base64 import to restore/sync datasets.
+- 3-party cycle detection (`me -> A -> B -> me`) with maximum cancellable amount calculation.
+
+## Technical architecture
+
+- **Frontend:** React + TypeScript
+- **Build tool:** Vite
+- **State model:** In-memory React state (`rows`, `form`, `importText`) with persistence sync hooks.
+- **Storage:** Browser `localStorage` only (no server dependency).
+- **Encoding strategy:** UTF-8 JSON serialized and encoded/decoded via Base64 for portability.
+
+## Key logic areas
+
+- **Normalization and validation**
+  - Monetary values are normalized to non-negative, 2-decimal values.
+  - Email values are lowercased before storage.
+- **Import pipeline**
+  - Base64 decode -> UTF-8 decode -> JSON parse -> array validation -> ID repair.
+- **Cycle detection**
+  - Builds directed debt edges and searches 3-hop cycles that return to `me`.
+  - Cancellable amount is `min(edge1, edge2, edge3)`.
+
+## Local development
+
+From repository root:
+
+```bash
+cd static/dcc
+npm install
+npm run dev
+```
+
+## Production build
+
+```bash
+cd static/dcc
+npm run build
+```
+
+## Deployment notes
+
+- App is static and can be served by any static host.
+- Because data is local-first, user data portability relies on export/import strings.


### PR DESCRIPTION
### Motivation

- Replace the previous complex, multi-component DCC ledger with a simpler, local-first contact-based debt tracker focused on GBP balances and offline portability.
- Provide an easy export/import workflow and surface 3-party debt cancellation opportunities for small group reconciliation.

### Description

- Reimplemented `App.tsx` to a self-contained React + TypeScript UI that stores per-contact debts (`name`, `email`, `theyOweMeGbp`, `iOweThemGbp`) in `localStorage` under the key `dcc-circle-cache-v1` and removed the previous multi-component architecture and many unused imports. 
- Added `cleanMoney` normalization, `ContactDebt` and `Edge` types, and hooks for loading/saving cached rows, plus an `exportedBase64` representation for easy sharing. 
- Implemented edge construction and 3-party cycle detection (`me -> A -> B -> me`) with cancellable amount calculation and de-duplication of suggestions. 
- Added UI for adding/removing rows, viewing people & debts, copying/exporting the Base64 string, and importing a Base64 dataset with validation and ID repair, and updated `README.md` to document features and local development steps.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123e9cdc148320a5805c94fd6cabe2)